### PR TITLE
timber 적용

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -37,6 +37,7 @@ android {
     }
     buildFeatures {
         dataBinding = true
+        buildConfig = true
     }
 }
 
@@ -51,6 +52,7 @@ dependencies {
     implementation(libs.navigation.fragment.ktx)
     implementation(libs.navigation.ui.ktx)
 
-    testImplementation(libs.junit)
+    implementation(libs.timber)
 
+    testImplementation(libs.junit)
 }

--- a/android/app/src/main/java/com/ohdodok/catchytape/CtApplication.kt
+++ b/android/app/src/main/java/com/ohdodok/catchytape/CtApplication.kt
@@ -2,6 +2,22 @@ package com.ohdodok.catchytape
 
 import android.app.Application
 import dagger.hilt.android.HiltAndroidApp
+import timber.log.Timber
 
 @HiltAndroidApp
-class CtApplication : Application()
+class CtApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        if (BuildConfig.DEBUG) {
+            Timber.plant(object : Timber.DebugTree() {
+                override fun createStackElementTag(element: StackTraceElement): String {
+                    return String.format(
+                        applicationContext.getString(R.string.timber_log_format),
+                        super.createStackElementTag(element),
+                        element.lineNumber,
+                    )
+                }
+            })
+        }
+    }
+}

--- a/android/app/src/main/java/com/ohdodok/catchytape/CtApplication.kt
+++ b/android/app/src/main/java/com/ohdodok/catchytape/CtApplication.kt
@@ -12,7 +12,7 @@ class CtApplication : Application() {
             Timber.plant(object : Timber.DebugTree() {
                 override fun createStackElementTag(element: StackTraceElement): String {
                     return String.format(
-                        applicationContext.getString(R.string.timber_log_format),
+                        getString(R.string.timber_log_format),
                         super.createStackElementTag(element),
                         element.lineNumber,
                     )

--- a/android/app/src/main/java/com/ohdodok/catchytape/MainActivity.kt
+++ b/android/app/src/main/java/com/ohdodok/catchytape/MainActivity.kt
@@ -10,6 +10,5 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
-        Timber.d("hello")
     }
 }

--- a/android/app/src/main/java/com/ohdodok/catchytape/MainActivity.kt
+++ b/android/app/src/main/java/com/ohdodok/catchytape/MainActivity.kt
@@ -3,11 +3,13 @@ package com.ohdodok.catchytape
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import dagger.hilt.android.AndroidEntryPoint
+import timber.log.Timber
 
 @AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+        Timber.d("hello")
     }
 }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name">Catchy Tape</string>
+    <string name="timber_log_format">C: %s: / L: %s</string>
 </resources>

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -18,6 +18,8 @@ okhttp = "4.10.0"
 kotlinx-serialization = "1.6.0"
 kotlinx-serialization-converter = "1.0.0"
 
+timber = "5.0.1"
+
 [libraries]
 android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "agp" }
 kotlin-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
@@ -40,6 +42,7 @@ okhttp-logging-interceptor = { module = "com.squareup.okhttp3:logging-intercepto
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 kotlinx-serialization-converter = { module = "com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter", version.ref = "kotlinx-serialization-converter" }
 
+timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
 
 
 [plugins]


### PR DESCRIPTION
## Issue
- #75 

## Overview
- `override fun createStackElementTag` 을 통해 추후에 커스텀 가능

## To Reviewers
- git pull 하시고, gradle sync 했는데도, `BuildConfig` 인식 안되면, 스튜디오에서 clean and rebuild project 하시면 됩니다
