### PR TITLE
keystore 공유를 위한 설정

### DIFF
--- a/.github/workflows/android-pull-request-ci.yml
+++ b/.github/workflows/android-pull-request-ci.yml
@@ -30,6 +30,8 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
+      - run: echo $DEBUG_KEYSTORE | base64 -d > keystore.properties
+
       - name: Run unit tests
         run: ./gradlew testDebugUnitTest --stacktrace
 

--- a/.github/workflows/android-pull-request-ci.yml
+++ b/.github/workflows/android-pull-request-ci.yml
@@ -30,10 +30,14 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - run: echo $DEBUG_KEYSTORE | base64 -d > keystore.properties
-
       - name: Run unit tests
-        run: ./gradlew testDebugUnitTest --stacktrace
+        env:
+          DEBUG_KEYSTORE: ${{ secrets.DEBUG_KEYSTORE }}
+          KEYSTORE_PROPERTIES: ${{ secrets.KEYSTORE_PROPERTIES }}
+        run: |
+          echo "$DEBUG_KEYSTORE" | base64 -d > keystore.properties
+          echo "$KEYSTORE_PROPERTIES" > keystore.properties
+          ./gradlew testDebugUnitTest --stacktrace
 
       - name: Publish Test Results
         if: always()

--- a/android/.gitignore
+++ b/android/.gitignore
@@ -24,6 +24,7 @@ render.experimental.xml
 # Keystore files
 *.jks
 *.keystore
+keystore.properties
 
 # Google Services (e.g. APIs or Firebase)
 google-services.json

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -27,7 +27,7 @@ android {
     }
 
     signingConfigs {
-        create("debug") {
+        getByName("debug") {
             keyAlias = keystoreProperties["debug.keyAlias"] as String
             keyPassword = keystoreProperties["debug.keyPassword"] as String
             storeFile = file(keystoreProperties["debug.storeFile"] as String)

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,9 +1,16 @@
+import java.util.Properties
+import java.io.FileInputStream
+
 @Suppress("DSL_SCOPE_VIOLATION") // TODO: Remove once KTIJ-19369 is fixed
 plugins {
     alias(libs.plugins.com.android.application)
     alias(libs.plugins.org.jetbrains.kotlin.android)
     id("catchytape.android.hilt")
 }
+
+val keystorePropertiesFile = rootProject.file("keystore.properties")
+val keystoreProperties = Properties()
+keystoreProperties.load(FileInputStream(keystorePropertiesFile))
 
 android {
     namespace = "com.ohdodok.catchytape"
@@ -17,6 +24,15 @@ android {
         versionName = "1.0.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    signingConfigs {
+        create("debug") {
+            keyAlias = keystoreProperties["debug.keyAlias"] as String
+            keyPassword = keystoreProperties["debug.keyPassword"] as String
+            storeFile = file(keystoreProperties["debug.storeFile"] as String)
+            storePassword = keystoreProperties["debug.storePassword"] as String
+        }
     }
 
     buildTypes {


### PR DESCRIPTION
## Issue
- #89 

## Overview
- 디버그 사이닝 키스토어를 공유할 수 있다.
- GitHub Actions settings에 debug.keystore 및 keystore.properties 추가
- workflow에서 해당 변수를 가져오도록 설정
- 빌드시 build.gradle에 명시된 keystore를 통해 사이닝

