### PR TITLE
build type에 따른 httpinterceptor Logging

### DIFF
--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
 <resources>
     <string name="app_name">Catchy Tape</string>
-    <string name="timber_log_format">C: %s: / L: %s</string>
+    <string name="timber_log_format">C: %s, L: %s</string>
 </resources>

--- a/android/build-logic/src/main/kotlin/gradle/plugin/AndroidFeaturePlugin.kt
+++ b/android/build-logic/src/main/kotlin/gradle/plugin/AndroidFeaturePlugin.kt
@@ -29,7 +29,6 @@ class AndroidFeaturePlugin : Plugin<Project> {
             dependencies {
                 add("implementation", project(":core:ui"))
                 add("implementation", project(":core:domain"))
-                add("implementation", libs.findLibrary("timber").get())
 
                 add("testImplementation", libs.findLibrary("junit").get())
             }

--- a/android/build-logic/src/main/kotlin/gradle/plugin/AndroidLibraryPlugin.kt
+++ b/android/build-logic/src/main/kotlin/gradle/plugin/AndroidLibraryPlugin.kt
@@ -4,7 +4,10 @@ import com.android.build.gradle.LibraryExtension
 import org.gradle.api.JavaVersion
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.artifacts.VersionCatalogsExtension
 import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.dependencies
+import org.gradle.kotlin.dsl.getByType
 
 internal class AndroidLibraryPlugin : Plugin<Project> {
 
@@ -21,6 +24,12 @@ internal class AndroidLibraryPlugin : Plugin<Project> {
                 sourceCompatibility = JavaVersion.VERSION_17
                 targetCompatibility = JavaVersion.VERSION_17
             }
+        }
+
+        val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
+
+        dependencies {
+            add("implementation", libs.findLibrary("timber").get())
         }
     }
 }

--- a/android/core/data/build.gradle.kts
+++ b/android/core/data/build.gradle.kts
@@ -40,4 +40,6 @@ dependencies {
     implementation(libs.okhttp.logging.interceptor)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.kotlinx.serialization.converter)
+    implementation(libs.timber)
+
 }

--- a/android/core/data/build.gradle.kts
+++ b/android/core/data/build.gradle.kts
@@ -40,6 +40,5 @@ dependencies {
     implementation(libs.okhttp.logging.interceptor)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.kotlinx.serialization.converter)
-    implementation(libs.timber)
 
 }

--- a/android/core/data/build.gradle.kts
+++ b/android/core/data/build.gradle.kts
@@ -22,8 +22,13 @@ android {
             )
         }
     }
+
     kotlinOptions {
         jvmTarget = "17"
+    }
+
+    buildFeatures {
+        buildConfig = true
     }
 }
 

--- a/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/di/NetworkModule.kt
+++ b/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/di/NetworkModule.kt
@@ -1,6 +1,7 @@
 package com.ohdodok.catchytape.core.data.di
 
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
+import com.ohdodok.catchytape.core.data.BuildConfig
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -13,7 +14,6 @@ import retrofit2.Retrofit
 import javax.inject.Singleton
 
 
-
 @Module
 @InstallIn(SingletonComponent::class)
 object NetworkModule {
@@ -21,12 +21,13 @@ object NetworkModule {
     @Singleton
     @Provides
     fun provideOkHttpClient(): OkHttpClient {
-        val httpLoggingInterceptor = HttpLoggingInterceptor()
-            .setLevel(HttpLoggingInterceptor.Level.BODY)
+        val httpLoggingInterceptor = HttpLoggingInterceptor().apply {
+            level = if (BuildConfig.DEBUG) HttpLoggingInterceptor.Level.BODY else HttpLoggingInterceptor.Level.NONE
+        }
+
         return OkHttpClient.Builder()
             .addInterceptor(httpLoggingInterceptor)
             .build()
-
     }
 
     @Singleton

--- a/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/di/NetworkModule.kt
+++ b/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/di/NetworkModule.kt
@@ -1,7 +1,6 @@
 package com.ohdodok.catchytape.core.data.di
 
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
-import com.ohdodok.catchytape.core.data.BuildConfig
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn

--- a/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/di/NetworkModule.kt
+++ b/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/di/NetworkModule.kt
@@ -11,6 +11,7 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
+import timber.log.Timber
 import javax.inject.Singleton
 
 
@@ -21,12 +22,12 @@ object NetworkModule {
     @Singleton
     @Provides
     fun provideOkHttpClient(): OkHttpClient {
-        val httpLoggingInterceptor = HttpLoggingInterceptor().apply {
-            level = if (BuildConfig.DEBUG) HttpLoggingInterceptor.Level.BODY else HttpLoggingInterceptor.Level.NONE
-        }
+        val logger = HttpLoggingInterceptor.Logger { message -> Timber.tag("okHttp").d(message) }
+        val httpInterceptor = HttpLoggingInterceptor(logger)
+            .setLevel(HttpLoggingInterceptor.Level.BODY)
 
         return OkHttpClient.Builder()
-            .addInterceptor(httpLoggingInterceptor)
+            .addInterceptor(httpInterceptor)
             .build()
     }
 

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ gms = "20.7.0"
 junit = "4.13.2"
 
 retrofit = "2.9.0"
-okhttp = "4.10.0"
+okhttp = "4.11.0"
 kotlinx-serialization = "1.6.0"
 kotlinx-serialization-converter = "1.0.0"
 


### PR DESCRIPTION
## Issue
- #75 

## Overview
https://github.com/boostcampwm2023/and04-catchy-tape/pull/76#issuecomment-1810203177

### 실험 해본 결과
- httpLoggingInterceptor 에서 따로 처리를 해야만, release build 시에 Log 가 출력 안되는 걸로 확인되었습니다.
    - 코멘트 주신대로 그 부분 처리했습니다.
- `timber_log_format` 도 약간 수정했습니다 ('/' 가 있으면 좀 다르게 출력되어 뺐습니다.)


