### PR TITLE
구글 로그인

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -62,6 +62,7 @@ dependencies {
     implementation(project(":feature:home"))
     implementation(project(":feature:login"))
     implementation(project(":feature:upload"))
+    implementation(project(":core:data"))
 
     implementation(libs.core.ktx)
     implementation(libs.appcompat)

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
         android:usesCleartextTraffic="true"
         android:theme="@style/Theme.CatchyTape">
         <activity
-            android:name=".feature.login.LoginActivity"
+            android:name=".MainActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
+        android:usesCleartextTraffic="true"
         android:theme="@style/Theme.CatchyTape">
         <activity
             android:name=".feature.login.LoginActivity"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -11,7 +11,7 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.CatchyTape">
         <activity
-            android:name=".MainActivity"
+            android:name=".feature.login.LoginActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/android/app/src/main/java/com/ohdodok/catchytape/MainActivity.kt
+++ b/android/app/src/main/java/com/ohdodok/catchytape/MainActivity.kt
@@ -1,14 +1,19 @@
 package com.ohdodok.catchytape
 
+import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import com.ohdodok.catchytape.feature.login.LoginActivity
 import dagger.hilt.android.AndroidEntryPoint
-import timber.log.Timber
 
 @AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+
+        // TODO : 자동로그인 할 때 수정 필요
+        val intent = Intent(this, LoginActivity::class.java)
+        startActivity(intent)
     }
 }

--- a/android/core/data/build.gradle.kts
+++ b/android/core/data/build.gradle.kts
@@ -5,6 +5,7 @@ import java.io.FileInputStream
 plugins {
     id("catchytape.android.library")
     id("catchytape.android.hilt")
+    id("kotlinx-serialization")
 }
 
 val localPropertiesFile = rootProject.file("local.properties")

--- a/android/core/data/build.gradle.kts
+++ b/android/core/data/build.gradle.kts
@@ -1,14 +1,22 @@
+import java.util.Properties
+import java.io.FileInputStream
+
 @Suppress("DSL_SCOPE_VIOLATION") // TODO: Remove once KTIJ-19369 is fixed
 plugins {
     id("catchytape.android.library")
     id("catchytape.android.hilt")
 }
 
+val localPropertiesFile = rootProject.file("local.properties")
+val localProperties = Properties()
+localProperties.load(FileInputStream(localPropertiesFile))
+
 android {
     namespace = "com.ohdodok.catchytape.core.data"
 
     defaultConfig {
 
+        buildConfigField("String", "BASE_URL", localProperties["server.url"] as String)
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
     }

--- a/android/core/data/build.gradle.kts
+++ b/android/core/data/build.gradle.kts
@@ -40,5 +40,6 @@ dependencies {
     implementation(libs.okhttp.logging.interceptor)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.kotlinx.serialization.converter)
+    implementation(libs.datastore.preferences)
 
 }

--- a/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/api/UserApi.kt
+++ b/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/api/UserApi.kt
@@ -2,6 +2,7 @@ package com.ohdodok.catchytape.core.data.api
 
 import com.ohdodok.catchytape.core.data.model.LoginRequest
 import com.ohdodok.catchytape.core.data.model.LoginResponse
+import com.ohdodok.catchytape.core.data.model.SignUpRequest
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.POST
@@ -11,6 +12,11 @@ interface UserApi {
     @POST("users/login")
     suspend fun login(
         @Body loginRequest: LoginRequest
+    ): Response<LoginResponse>
+
+    @POST("users/signup")
+    suspend fun signUp(
+        @Body signUpRequest: SignUpRequest
     ): Response<LoginResponse>
 
 }

--- a/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/api/UserApi.kt
+++ b/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/api/UserApi.kt
@@ -8,11 +8,9 @@ import retrofit2.http.POST
 
 interface UserApi {
 
-    @POST("user/login")
+    @POST("users/login")
     suspend fun login(
         @Body loginRequest: LoginRequest
     ): Response<LoginResponse>
-
-    suspend fun saveToken(token: String)
 
 }

--- a/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/api/UserApi.kt
+++ b/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/api/UserApi.kt
@@ -13,4 +13,6 @@ interface UserApi {
         @Body loginRequest: LoginRequest
     ): Response<LoginResponse>
 
+    suspend fun saveToken(token: String)
+
 }

--- a/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/api/UserApi.kt
+++ b/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/api/UserApi.kt
@@ -1,0 +1,16 @@
+package com.ohdodok.catchytape.core.data.api
+
+import com.ohdodok.catchytape.core.data.model.LoginRequest
+import com.ohdodok.catchytape.core.data.model.LoginResponse
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface UserApi {
+
+    @POST("user/login")
+    suspend fun login(
+        @Body loginRequest: LoginRequest
+    ): Response<LoginResponse>
+
+}

--- a/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/di/ApiModule.kt
+++ b/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/di/ApiModule.kt
@@ -1,0 +1,20 @@
+package com.ohdodok.catchytape.core.data.di
+
+import com.ohdodok.catchytape.core.data.api.UserApi
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object ApiModule {
+
+    @Provides
+    @Singleton
+    fun provideSignupApi(retrofit: Retrofit): UserApi {
+        return retrofit.create(UserApi::class.java)
+    }
+}

--- a/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/di/DataStoreModule.kt
+++ b/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/di/DataStoreModule.kt
@@ -1,0 +1,28 @@
+package com.ohdodok.catchytape.core.data.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.dataStoreFile
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object DataStoreModule {
+
+    private const val USER_PREFERENCES = "user_preferences"
+
+    @Provides
+    @Singleton
+    fun provideUserPreferenceDataStore(@ApplicationContext context: Context): DataStore<Preferences> {
+        return PreferenceDataStoreFactory.create(
+            produceFile = { context.dataStoreFile(USER_PREFERENCES) }
+        )
+    }
+}

--- a/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/di/DataStoreModule.kt
+++ b/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/di/DataStoreModule.kt
@@ -2,9 +2,9 @@ package com.ohdodok.catchytape.core.data.di
 
 import android.content.Context
 import androidx.datastore.core.DataStore
-import androidx.datastore.dataStoreFile
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStoreFile
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -22,7 +22,7 @@ object DataStoreModule {
     @Singleton
     fun provideUserPreferenceDataStore(@ApplicationContext context: Context): DataStore<Preferences> {
         return PreferenceDataStoreFactory.create(
-            produceFile = { context.dataStoreFile(USER_PREFERENCES) }
+            produceFile = { context.preferencesDataStoreFile(USER_PREFERENCES) }
         )
     }
 }

--- a/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/di/NetworkModule.kt
+++ b/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/di/NetworkModule.kt
@@ -1,6 +1,7 @@
 package com.ohdodok.catchytape.core.data.di
 
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
+import com.ohdodok.catchytape.core.data.BuildConfig
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -36,7 +37,7 @@ object NetworkModule {
         return Retrofit.Builder()
             .addConverterFactory(Json.asConverterFactory("application/json".toMediaType()))
             .client(okHttpClient)
-            .baseUrl("")
+            .baseUrl(BuildConfig.BASE_URL)
             .build()
     }
 }

--- a/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/di/RepositoryModule.kt
+++ b/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/di/RepositoryModule.kt
@@ -1,0 +1,16 @@
+package com.ohdodok.catchytape.core.data.di
+
+import com.ohdodok.catchytape.core.data.repository.AuthRepositoryImpl
+import com.ohdodok.catchytape.core.domain.repository.AuthRepository
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+interface RepositoryModule {
+
+    @Binds
+    fun bindAuthRepository(authRepositoryImpl: AuthRepositoryImpl): AuthRepository
+}

--- a/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/model/LoginRequest.kt
+++ b/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/model/LoginRequest.kt
@@ -1,0 +1,5 @@
+package com.ohdodok.catchytape.core.data.model
+
+data class LoginRequest(
+    val idToken: String
+)

--- a/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/model/LoginRequest.kt
+++ b/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/model/LoginRequest.kt
@@ -1,5 +1,8 @@
 package com.ohdodok.catchytape.core.data.model
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class LoginRequest(
     val idToken: String
 )

--- a/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/model/LoginResponse.kt
+++ b/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/model/LoginResponse.kt
@@ -3,6 +3,6 @@ package com.ohdodok.catchytape.core.data.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class LoginResponse (
+data class LoginResponse(
     val accessToken: String
 )

--- a/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/model/LoginResponse.kt
+++ b/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/model/LoginResponse.kt
@@ -1,0 +1,5 @@
+package com.ohdodok.catchytape.core.data.model
+
+data class LoginResponse (
+    val accessToken: String
+)

--- a/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/model/LoginResponse.kt
+++ b/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/model/LoginResponse.kt
@@ -1,5 +1,8 @@
 package com.ohdodok.catchytape.core.data.model
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class LoginResponse (
     val accessToken: String
 )

--- a/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/model/SignUpRequest.kt
+++ b/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/model/SignUpRequest.kt
@@ -3,7 +3,7 @@ package com.ohdodok.catchytape.core.data.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class SignUpRequest (
+data class SignUpRequest(
     val nickname: String,
     val idToken: String
 )

--- a/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/model/SignUpRequest.kt
+++ b/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/model/SignUpRequest.kt
@@ -1,0 +1,9 @@
+package com.ohdodok.catchytape.core.data.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SignUpRequest (
+    val nickname: String,
+    val idToken: String
+)

--- a/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/repository/AuthRepositoryImpl.kt
+++ b/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/repository/AuthRepositoryImpl.kt
@@ -20,12 +20,12 @@ class AuthRepositoryImpl @Inject constructor(
 ) : AuthRepository {
 
     override fun loginWithGoogle(googleToken: String): Flow<String> = flow {
-        userApi.login(LoginRequest(googleToken)).let { response ->
+        userApi.login(LoginRequest(idToken = googleToken)).let { response ->
             if (response.isSuccessful) {
                 response.body()?.let { loginResponse ->
                     emit(loginResponse.accessToken)
                 }
-            } else if(response.code() == 401){
+            } else if (response.code() == 401) {
                 // TODO : 네트워크 에러 로직
                 throw Exception("존재하지 않는 유저입니다.")
             }
@@ -33,10 +33,10 @@ class AuthRepositoryImpl @Inject constructor(
     }
 
     override fun signUpWithGoogle(googleToken: String, nickname: String): Flow<Unit> = flow {
-        userApi.signUp(SignUpRequest(googleToken, nickname)).let { response ->
+        userApi.signUp(SignUpRequest(idToken = googleToken, nickname = nickname)).let { response ->
             if (response.isSuccessful) {
                 response.body()?.let { _ -> emit(Unit) }
-            }else {
+            } else {
                 // TODO : 네트워크 에러 로직
                 throw Exception("회원 가입 실패")
             }

--- a/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/repository/AuthRepositoryImpl.kt
+++ b/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/repository/AuthRepositoryImpl.kt
@@ -6,16 +6,16 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import com.ohdodok.catchytape.core.data.api.UserApi
 import com.ohdodok.catchytape.core.data.model.LoginRequest
-import com.ohdodok.catchytape.core.data.repository.UserRepositoryImpl.PreferenceKeys.USER_TOKEN
-import com.ohdodok.catchytape.core.domain.repository.UserRepository
+import com.ohdodok.catchytape.core.data.repository.AuthRepositoryImpl.PreferenceKeys.USER_TOKEN
+import com.ohdodok.catchytape.core.domain.repository.AuthRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
-class UserRepositoryImpl @Inject constructor(
+class AuthRepositoryImpl @Inject constructor(
     private val userApi: UserApi,
     private val preferenceDataStore: DataStore<Preferences>
-) : UserRepository {
+) : AuthRepository {
 
     override suspend fun loginWithGoogle(googleToken: String) {
         userApi.login(LoginRequest(googleToken))

--- a/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/repository/AuthRepositoryImpl.kt
+++ b/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/repository/AuthRepositoryImpl.kt
@@ -6,6 +6,7 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import com.ohdodok.catchytape.core.data.api.UserApi
 import com.ohdodok.catchytape.core.data.model.LoginRequest
+import com.ohdodok.catchytape.core.data.model.SignUpRequest
 import com.ohdodok.catchytape.core.data.repository.AuthRepositoryImpl.PreferenceKeys.USER_TOKEN
 import com.ohdodok.catchytape.core.domain.repository.AuthRepository
 import kotlinx.coroutines.flow.Flow
@@ -29,6 +30,10 @@ class AuthRepositoryImpl @Inject constructor(
                 throw Exception("로그인 실패")
             }
         }
+    }
+
+    override fun signUpWithGoogle(googleToken: String, nickname: String): Flow<Unit> = flow {
+        userApi.signUp(SignUpRequest(googleToken, nickname))
     }
 
     override suspend fun saveToken(token: String) {

--- a/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/repository/AuthRepositoryImpl.kt
+++ b/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/repository/AuthRepositoryImpl.kt
@@ -7,7 +7,6 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import com.ohdodok.catchytape.core.data.api.UserApi
 import com.ohdodok.catchytape.core.data.model.LoginRequest
 import com.ohdodok.catchytape.core.data.model.SignUpRequest
-import com.ohdodok.catchytape.core.data.repository.AuthRepositoryImpl.PreferenceKeys.USER_TOKEN
 import com.ohdodok.catchytape.core.domain.repository.AuthRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -17,6 +16,8 @@ class AuthRepositoryImpl @Inject constructor(
     private val userApi: UserApi,
     private val preferenceDataStore: DataStore<Preferences>
 ) : AuthRepository {
+
+    private val tokenKey = stringPreferencesKey("token")
 
     override fun loginWithGoogle(googleToken: String): Flow<String> = flow {
         userApi.login(LoginRequest(idToken = googleToken)).let { response ->
@@ -45,10 +46,7 @@ class AuthRepositoryImpl @Inject constructor(
     }
 
     override suspend fun saveToken(token: String) {
-        preferenceDataStore.edit { preferences -> preferences[USER_TOKEN] = token }
+        preferenceDataStore.edit { preferences -> preferences[tokenKey] = token }
     }
 
-    object PreferenceKeys {
-        val USER_TOKEN = stringPreferencesKey("token")
-    }
 }

--- a/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/repository/AuthRepositoryImpl.kt
+++ b/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/repository/AuthRepositoryImpl.kt
@@ -24,7 +24,8 @@ class AuthRepositoryImpl @Inject constructor(
                 response.body()?.let { loginResponse ->
                     emit(loginResponse.accessToken)
                 }
-            } else {
+            } else if(response.code() == 401){
+                // 존재하지 않는 유저
                 throw Exception("로그인 실패")
             }
         }

--- a/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/repository/AuthRepositoryImpl.kt
+++ b/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/repository/AuthRepositoryImpl.kt
@@ -33,7 +33,15 @@ class AuthRepositoryImpl @Inject constructor(
     }
 
     override fun signUpWithGoogle(googleToken: String, nickname: String): Flow<Unit> = flow {
-        userApi.signUp(SignUpRequest(googleToken, nickname))
+        userApi.signUp(SignUpRequest(googleToken, nickname)).let { response ->
+            if (response.isSuccessful) {
+                response.body()?.let { _ ->
+                    emit(Unit)
+                }
+            }else {
+                throw Exception("회원가입 실패")
+            }
+        }
     }
 
     override suspend fun saveToken(token: String) {

--- a/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/repository/AuthRepositoryImpl.kt
+++ b/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/repository/AuthRepositoryImpl.kt
@@ -11,7 +11,6 @@ import com.ohdodok.catchytape.core.data.repository.AuthRepositoryImpl.Preference
 import com.ohdodok.catchytape.core.domain.repository.AuthRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 class AuthRepositoryImpl @Inject constructor(
@@ -32,10 +31,12 @@ class AuthRepositoryImpl @Inject constructor(
         }
     }
 
-    override fun signUpWithGoogle(googleToken: String, nickname: String): Flow<Unit> = flow {
+    override fun signUpWithGoogle(googleToken: String, nickname: String): Flow<String> = flow {
         userApi.signUp(SignUpRequest(idToken = googleToken, nickname = nickname)).let { response ->
             if (response.isSuccessful) {
-                response.body()?.let { _ -> emit(Unit) }
+                response.body()?.let { loginResponse ->
+                    emit(loginResponse.accessToken)
+                }
             } else {
                 // TODO : 네트워크 에러 로직
                 throw Exception("회원 가입 실패")

--- a/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/repository/AuthRepositoryImpl.kt
+++ b/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/repository/AuthRepositoryImpl.kt
@@ -44,15 +44,7 @@ class AuthRepositoryImpl @Inject constructor(
     }
 
     override suspend fun saveToken(token: String) {
-        preferenceDataStore.edit { preferences ->
-            preferences[USER_TOKEN] = token
-        }
-    }
-
-    override fun getToken(): Flow<String> {
-        return preferenceDataStore.data.map { preference ->
-            preference[USER_TOKEN] ?: ""
-        }
+        preferenceDataStore.edit { preferences -> preferences[USER_TOKEN] = token }
     }
 
     object PreferenceKeys {

--- a/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/repository/AuthRepositoryImpl.kt
+++ b/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/repository/AuthRepositoryImpl.kt
@@ -26,8 +26,8 @@ class AuthRepositoryImpl @Inject constructor(
                     emit(loginResponse.accessToken)
                 }
             } else if(response.code() == 401){
-                // 존재하지 않는 유저
-                throw Exception("로그인 실패")
+                // TODO : 네트워크 에러 로직
+                throw Exception("존재하지 않는 유저입니다.")
             }
         }
     }
@@ -35,11 +35,10 @@ class AuthRepositoryImpl @Inject constructor(
     override fun signUpWithGoogle(googleToken: String, nickname: String): Flow<Unit> = flow {
         userApi.signUp(SignUpRequest(googleToken, nickname)).let { response ->
             if (response.isSuccessful) {
-                response.body()?.let { _ ->
-                    emit(Unit)
-                }
+                response.body()?.let { _ -> emit(Unit) }
             }else {
-                throw Exception("회원가입 실패")
+                // TODO : 네트워크 에러 로직
+                throw Exception("회원 가입 실패")
             }
         }
     }
@@ -50,7 +49,7 @@ class AuthRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun getToken(): Flow<String> {
+    override fun getToken(): Flow<String> {
         return preferenceDataStore.data.map { preference ->
             preference[USER_TOKEN] ?: ""
         }

--- a/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/repository/AuthRepositoryImpl.kt
+++ b/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/repository/AuthRepositoryImpl.kt
@@ -9,6 +9,7 @@ import com.ohdodok.catchytape.core.data.model.LoginRequest
 import com.ohdodok.catchytape.core.data.repository.AuthRepositoryImpl.PreferenceKeys.USER_TOKEN
 import com.ohdodok.catchytape.core.domain.repository.AuthRepository
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
@@ -17,8 +18,16 @@ class AuthRepositoryImpl @Inject constructor(
     private val preferenceDataStore: DataStore<Preferences>
 ) : AuthRepository {
 
-    override suspend fun loginWithGoogle(googleToken: String) {
-        userApi.login(LoginRequest(googleToken))
+    override fun loginWithGoogle(googleToken: String): Flow<String> = flow {
+        userApi.login(LoginRequest(googleToken)).let { response ->
+            if (response.isSuccessful) {
+                response.body()?.let { loginResponse ->
+                    emit(loginResponse.accessToken)
+                }
+            } else {
+                throw Exception("로그인 실패")
+            }
+        }
     }
 
     override suspend fun saveToken(token: String) {

--- a/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/repository/AuthRepositoryImpl.kt
+++ b/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/repository/AuthRepositoryImpl.kt
@@ -20,30 +20,29 @@ class AuthRepositoryImpl @Inject constructor(
     private val tokenKey = stringPreferencesKey("token")
 
     override fun loginWithGoogle(googleToken: String): Flow<String> = flow {
-        userApi.login(LoginRequest(idToken = googleToken)).let { response ->
-            if (response.isSuccessful) {
-                response.body()?.let { loginResponse ->
-                    emit(loginResponse.accessToken)
-                }
-            } else if (response.code() == 401) {
-                // TODO : 네트워크 에러 로직
-                throw Exception("존재하지 않는 유저입니다.")
+        val response = userApi.login(LoginRequest(idToken = googleToken))
+        if (response.isSuccessful) {
+            response.body()?.let { loginResponse ->
+                emit(loginResponse.accessToken)
             }
+        } else if (response.code() == 401) {
+            // TODO : 네트워크 에러 로직
+            throw Exception("존재하지 않는 유저입니다.")
         }
     }
 
     override fun signUpWithGoogle(googleToken: String, nickname: String): Flow<String> = flow {
-        userApi.signUp(SignUpRequest(idToken = googleToken, nickname = nickname)).let { response ->
-            if (response.isSuccessful) {
-                response.body()?.let { loginResponse ->
-                    emit(loginResponse.accessToken)
-                }
-            } else {
-                // TODO : 네트워크 에러 로직
-                throw Exception("회원 가입 실패")
+        val response = userApi.signUp(SignUpRequest(idToken = googleToken, nickname = nickname))
+        if (response.isSuccessful) {
+            response.body()?.let { loginResponse ->
+                emit(loginResponse.accessToken)
             }
+        } else {
+            // TODO : 네트워크 에러 로직
+            throw Exception("회원 가입 실패")
         }
     }
+
 
     override suspend fun saveToken(token: String) {
         preferenceDataStore.edit { preferences -> preferences[tokenKey] = token }

--- a/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/repository/UserRepositoryImpl.kt
+++ b/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/repository/UserRepositoryImpl.kt
@@ -1,15 +1,31 @@
 package com.ohdodok.catchytape.core.data.repository
 
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
 import com.ohdodok.catchytape.core.data.api.UserApi
 import com.ohdodok.catchytape.core.data.model.LoginRequest
+import com.ohdodok.catchytape.core.data.repository.UserRepositoryImpl.PreferenceKeys.USER_TOKEN
 import com.ohdodok.catchytape.core.domain.repository.UserRepository
 import javax.inject.Inject
 
 class UserRepositoryImpl @Inject constructor(
-    private val userApi: UserApi
+    private val userApi: UserApi,
+    private val preferenceDataStore: DataStore<Preferences>
 ) : UserRepository {
 
     override suspend fun loginWithGoogle(googleToken: String) {
         userApi.login(LoginRequest(googleToken))
+    }
+
+    override suspend fun saveToken(token: String) {
+        preferenceDataStore.edit { preferences ->
+            preferences[USER_TOKEN] = token
+        }
+    }
+
+    object PreferenceKeys {
+        val USER_TOKEN = stringPreferencesKey("token")
     }
 }

--- a/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/repository/UserRepositoryImpl.kt
+++ b/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/repository/UserRepositoryImpl.kt
@@ -8,6 +8,8 @@ import com.ohdodok.catchytape.core.data.api.UserApi
 import com.ohdodok.catchytape.core.data.model.LoginRequest
 import com.ohdodok.catchytape.core.data.repository.UserRepositoryImpl.PreferenceKeys.USER_TOKEN
 import com.ohdodok.catchytape.core.domain.repository.UserRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 class UserRepositoryImpl @Inject constructor(
@@ -22,6 +24,12 @@ class UserRepositoryImpl @Inject constructor(
     override suspend fun saveToken(token: String) {
         preferenceDataStore.edit { preferences ->
             preferences[USER_TOKEN] = token
+        }
+    }
+
+    override suspend fun getToken(): Flow<String> {
+        return preferenceDataStore.data.map { preference ->
+            preference[USER_TOKEN] ?: ""
         }
     }
 

--- a/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/repository/UserRepositoryImpl.kt
+++ b/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/repository/UserRepositoryImpl.kt
@@ -1,0 +1,15 @@
+package com.ohdodok.catchytape.core.data.repository
+
+import com.ohdodok.catchytape.core.data.api.UserApi
+import com.ohdodok.catchytape.core.data.model.LoginRequest
+import com.ohdodok.catchytape.core.domain.repository.UserRepository
+import javax.inject.Inject
+
+class UserRepositoryImpl @Inject constructor(
+    private val userApi: UserApi
+) : UserRepository {
+
+    override suspend fun loginWithGoogle(googleToken: String) {
+        userApi.login(LoginRequest(googleToken))
+    }
+}

--- a/android/core/domain/build.gradle.kts
+++ b/android/core/domain/build.gradle.kts
@@ -4,5 +4,5 @@ plugins {
 }
 
 dependencies {
-
+    api(libs.coroutines)
 }

--- a/android/core/domain/build.gradle.kts
+++ b/android/core/domain/build.gradle.kts
@@ -5,4 +5,5 @@ plugins {
 
 dependencies {
     api(libs.coroutines)
+    implementation(libs.inject)
 }

--- a/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/repository/AuthRepository.kt
+++ b/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/repository/AuthRepository.kt
@@ -10,6 +10,4 @@ interface AuthRepository {
 
     suspend fun saveToken(token: String)
 
-    fun getToken(): Flow<String>
-
 }

--- a/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/repository/AuthRepository.kt
+++ b/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/repository/AuthRepository.kt
@@ -3,7 +3,8 @@ package com.ohdodok.catchytape.core.domain.repository
 import kotlinx.coroutines.flow.Flow
 
 interface AuthRepository {
-    suspend fun loginWithGoogle(googleToken: String)
+
+    fun loginWithGoogle(googleToken: String): Flow<String>
 
     suspend fun saveToken(token: String)
 

--- a/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/repository/AuthRepository.kt
+++ b/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/repository/AuthRepository.kt
@@ -6,6 +6,8 @@ interface AuthRepository {
 
     fun loginWithGoogle(googleToken: String): Flow<String>
 
+    fun signUpWithGoogle(googleToken: String, nickname: String): Flow<Unit>
+
     suspend fun saveToken(token: String)
 
     suspend fun getToken(): Flow<String>

--- a/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/repository/AuthRepository.kt
+++ b/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/repository/AuthRepository.kt
@@ -10,6 +10,6 @@ interface AuthRepository {
 
     suspend fun saveToken(token: String)
 
-    suspend fun getToken(): Flow<String>
+    fun getToken(): Flow<String>
 
 }

--- a/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/repository/AuthRepository.kt
+++ b/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/repository/AuthRepository.kt
@@ -2,7 +2,7 @@ package com.ohdodok.catchytape.core.domain.repository
 
 import kotlinx.coroutines.flow.Flow
 
-interface UserRepository {
+interface AuthRepository {
     suspend fun loginWithGoogle(googleToken: String)
 
     suspend fun saveToken(token: String)

--- a/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/repository/AuthRepository.kt
+++ b/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/repository/AuthRepository.kt
@@ -6,7 +6,7 @@ interface AuthRepository {
 
     fun loginWithGoogle(googleToken: String): Flow<String>
 
-    fun signUpWithGoogle(googleToken: String, nickname: String): Flow<Unit>
+    fun signUpWithGoogle(googleToken: String, nickname: String): Flow<String>
 
     suspend fun saveToken(token: String)
 

--- a/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/repository/UserRepository.kt
+++ b/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/repository/UserRepository.kt
@@ -1,0 +1,5 @@
+package com.ohdodok.catchytape.core.domain.repository
+
+interface UserRepository {
+    suspend fun loginWithGoogle(googleToken: String)
+}

--- a/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/repository/UserRepository.kt
+++ b/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/repository/UserRepository.kt
@@ -1,8 +1,12 @@
 package com.ohdodok.catchytape.core.domain.repository
 
+import kotlinx.coroutines.flow.Flow
+
 interface UserRepository {
     suspend fun loginWithGoogle(googleToken: String)
 
     suspend fun saveToken(token: String)
+
+    suspend fun getToken(): Flow<String>
 
 }

--- a/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/repository/UserRepository.kt
+++ b/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/repository/UserRepository.kt
@@ -2,4 +2,7 @@ package com.ohdodok.catchytape.core.domain.repository
 
 interface UserRepository {
     suspend fun loginWithGoogle(googleToken: String)
+
+    suspend fun saveToken(token: String)
+
 }

--- a/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/usecase/LoginUseCase.kt
+++ b/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/usecase/LoginUseCase.kt
@@ -14,12 +14,10 @@ class LoginUseCase @Inject constructor(
     operator fun invoke(googleToken: String): Flow<Unit> = flow {
         authRepository.loginWithGoogle(googleToken)
             .catch {
-                // 존재하지 않는 유저
-                throw Exception("")
-            }
-            .collect {
+                throw Exception("존재하지 않는 유저입니다.")
+            }.collect {
                 // 존재하는 유저
                 authRepository.saveToken(it)
-        }
+            }
     }
 }

--- a/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/usecase/LoginUseCase.kt
+++ b/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/usecase/LoginUseCase.kt
@@ -2,22 +2,13 @@ package com.ohdodok.catchytape.core.domain.usecase
 
 import com.ohdodok.catchytape.core.domain.repository.AuthRepository
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 class LoginUseCase @Inject constructor(
     private val authRepository: AuthRepository
 ) {
 
-    operator fun invoke(googleToken: String): Flow<Unit> = flow {
-        authRepository.loginWithGoogle(googleToken)
-            .catch {
-                throw Exception("존재하지 않는 유저입니다.")
-            }.collect {
-                // 존재하는 유저
-                authRepository.saveToken(it)
-            }
-    }
+    operator fun invoke(googleToken: String): Flow<Unit> =
+        authRepository.loginWithGoogle(googleToken).map { authRepository.saveToken(it) }
 }

--- a/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/usecase/LoginUseCase.kt
+++ b/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/usecase/LoginUseCase.kt
@@ -1,0 +1,9 @@
+package com.ohdodok.catchytape.core.domain.usecase
+
+import com.ohdodok.catchytape.core.domain.repository.AuthRepository
+import javax.inject.Inject
+
+class LoginUseCase @Inject constructor(
+    private val authRepository: AuthRepository
+) {
+}

--- a/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/usecase/LoginUseCase.kt
+++ b/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/usecase/LoginUseCase.kt
@@ -1,9 +1,25 @@
 package com.ohdodok.catchytape.core.domain.usecase
 
 import com.ohdodok.catchytape.core.domain.repository.AuthRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
 class LoginUseCase @Inject constructor(
     private val authRepository: AuthRepository
 ) {
+
+    operator fun invoke(googleToken: String): Flow<Unit> = flow {
+        authRepository.loginWithGoogle(googleToken)
+            .catch {
+                // 존재하지 않는 유저
+                throw Exception("")
+            }
+            .collect {
+                // 존재하는 유저
+                authRepository.saveToken(it)
+        }
+    }
 }

--- a/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/usecase/SignUpUseCase.kt
+++ b/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/usecase/SignUpUseCase.kt
@@ -9,5 +9,5 @@ class SignUpUseCase @Inject constructor(
 ) {
 
     operator fun invoke(googleToken: String, nickname: String): Flow<Unit> =
-        authRepository.signUpWithGoogle(googleToken, nickname)
+        authRepository.signUpWithGoogle(googleToken = googleToken, nickname = nickname)
 }

--- a/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/usecase/SignUpUseCase.kt
+++ b/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/usecase/SignUpUseCase.kt
@@ -2,12 +2,18 @@ package com.ohdodok.catchytape.core.domain.usecase
 
 import com.ohdodok.catchytape.core.domain.repository.AuthRepository
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
 class SignUpUseCase @Inject constructor(
     private val authRepository: AuthRepository
 ) {
 
-    operator fun invoke(googleToken: String, nickname: String): Flow<Unit> =
-        authRepository.signUpWithGoogle(googleToken = googleToken, nickname = nickname)
+    operator fun invoke(googleToken: String, nickname: String): Flow<Unit> = flow {
+        authRepository.signUpWithGoogle(googleToken, nickname).collect {
+                authRepository.saveToken(it)
+                emit(Unit)
+            }
+    }
 }

--- a/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/usecase/SignUpUseCase.kt
+++ b/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/usecase/SignUpUseCase.kt
@@ -2,18 +2,14 @@ package com.ohdodok.catchytape.core.domain.usecase
 
 import com.ohdodok.catchytape.core.domain.repository.AuthRepository
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 class SignUpUseCase @Inject constructor(
     private val authRepository: AuthRepository
 ) {
 
-    operator fun invoke(googleToken: String, nickname: String): Flow<Unit> = flow {
-        authRepository.signUpWithGoogle(googleToken, nickname).collect {
-                authRepository.saveToken(it)
-                emit(Unit)
-            }
-    }
+    operator fun invoke(googleToken: String, nickname: String): Flow<Unit> =
+        authRepository.signUpWithGoogle(googleToken, nickname).map { authRepository.saveToken(it) }
+
 }

--- a/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/usecase/SignUpUseCase.kt
+++ b/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/usecase/SignUpUseCase.kt
@@ -1,0 +1,13 @@
+package com.ohdodok.catchytape.core.domain.usecase
+
+import com.ohdodok.catchytape.core.domain.repository.AuthRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class SignUpUseCase @Inject constructor(
+    private val authRepository: AuthRepository
+) {
+
+    operator fun invoke(googleToken: String, nickname: String): Flow<Unit> =
+        authRepository.signUpWithGoogle(googleToken, nickname)
+}

--- a/android/core/ui/src/main/java/com/ohdodok/catchytape/core/ui/BaseFragment.kt
+++ b/android/core/ui/src/main/java/com/ohdodok/catchytape/core/ui/BaseFragment.kt
@@ -8,8 +8,14 @@ import androidx.annotation.LayoutRes
 import androidx.databinding.DataBindingUtil
 import androidx.databinding.ViewDataBinding
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.appbar.MaterialToolbar
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 
 abstract class BaseFragment<VB : ViewDataBinding>(
     @LayoutRes private val layoutId: Int
@@ -36,6 +42,12 @@ abstract class BaseFragment<VB : ViewDataBinding>(
     protected fun setupBackStack(toolbar: MaterialToolbar){
         toolbar.setNavigationOnClickListener {
             findNavController().popBackStack()
+        }
+    }
+
+    fun LifecycleOwner.repeatOnStarted(block: suspend CoroutineScope.() -> Unit) {
+        viewLifecycleOwner.lifecycleScope.launch {
+            lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED, block)
         }
     }
 }

--- a/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/LoginFragment.kt
+++ b/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/LoginFragment.kt
@@ -7,11 +7,13 @@ import android.view.View
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions
 import com.ohdodok.catchytape.core.ui.BaseFragment
 import com.ohdodok.catchytape.feature.login.databinding.FragmentLoginBinding
 import dagger.hilt.android.AndroidEntryPoint
+import timber.log.Timber
 
 @AndroidEntryPoint
 class LoginFragment : BaseFragment<FragmentLoginBinding>(R.layout.fragment_login) {
@@ -20,12 +22,15 @@ class LoginFragment : BaseFragment<FragmentLoginBinding>(R.layout.fragment_login
 
     private val gso = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
         .requestIdToken(BuildConfig.GOOGLE_CLIENT_ID)
+        .requestEmail()
         .build()
 
     private val googleLoginLauncher: ActivityResultLauncher<Intent> =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
             if (result.resultCode == Activity.RESULT_OK) {
                 val task = GoogleSignIn.getSignedInAccountFromIntent(result.data)
+                Timber.d(task.result.idToken)
+                Timber.d(task.result.email)
                 viewModel.login(task.result.idToken, task.result.email)
             }
         }
@@ -34,12 +39,28 @@ class LoginFragment : BaseFragment<FragmentLoginBinding>(R.layout.fragment_login
         super.onViewCreated(view, savedInstanceState)
         binding.viewModel = viewModel
         setUpGoogleLoginBtn()
+        observeEvents()
     }
 
     private fun setUpGoogleLoginBtn() {
         binding.btnGoogleLogin.setOnClickListener {
             val googleSignInClient = GoogleSignIn.getClient(requireContext(), gso)
             googleLoginLauncher.launch(googleSignInClient.signInIntent)
+        }
+    }
+
+    private fun observeEvents() {
+        repeatOnStarted {
+            viewModel.events.collect { event ->
+                when (event) {
+                    is LoginEvent.NavigateToHome -> {
+
+                    }
+                    is LoginEvent.NavigateToNickName -> {
+                        findNavController().navigate(LoginFragmentDirections.actionLoginFragmentToNicknameFragment())
+                    }
+                }
+            }
         }
     }
 }

--- a/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/LoginFragment.kt
+++ b/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/LoginFragment.kt
@@ -52,8 +52,13 @@ class LoginFragment : BaseFragment<FragmentLoginBinding>(R.layout.fragment_login
                     is LoginEvent.NavigateToHome -> {
                         activity?.finish()
                     }
+
                     is LoginEvent.NavigateToNickName -> {
-                        findNavController().navigate(LoginFragmentDirections.actionLoginFragmentToNicknameFragment(googleToken = event.googleToken))
+                        findNavController().navigate(
+                            LoginFragmentDirections.actionLoginFragmentToNicknameFragment(
+                                googleToken = event.googleToken
+                            )
+                        )
                     }
                 }
             }

--- a/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/LoginFragment.kt
+++ b/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/LoginFragment.kt
@@ -21,6 +21,7 @@ class LoginFragment : BaseFragment<FragmentLoginBinding>(R.layout.fragment_login
 
     private val gso = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
         .requestIdToken(BuildConfig.GOOGLE_CLIENT_ID)
+        .requestEmail()
         .build()
 
     private val googleLoginLauncher: ActivityResultLauncher<Intent> =

--- a/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/LoginFragment.kt
+++ b/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/LoginFragment.kt
@@ -57,7 +57,7 @@ class LoginFragment : BaseFragment<FragmentLoginBinding>(R.layout.fragment_login
 
                     }
                     is LoginEvent.NavigateToNickName -> {
-                        findNavController().navigate(LoginFragmentDirections.actionLoginFragmentToNicknameFragment())
+                        findNavController().navigate(LoginFragmentDirections.actionLoginFragmentToNicknameFragment(googleToken = event.googleToken))
                     }
                 }
             }

--- a/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/LoginFragment.kt
+++ b/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/LoginFragment.kt
@@ -54,7 +54,7 @@ class LoginFragment : BaseFragment<FragmentLoginBinding>(R.layout.fragment_login
             viewModel.events.collect { event ->
                 when (event) {
                     is LoginEvent.NavigateToHome -> {
-
+                        activity?.finish()
                     }
                     is LoginEvent.NavigateToNickName -> {
                         findNavController().navigate(LoginFragmentDirections.actionLoginFragmentToNicknameFragment(googleToken = event.googleToken))

--- a/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/LoginFragment.kt
+++ b/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/LoginFragment.kt
@@ -29,8 +29,6 @@ class LoginFragment : BaseFragment<FragmentLoginBinding>(R.layout.fragment_login
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
             if (result.resultCode == Activity.RESULT_OK) {
                 val task = GoogleSignIn.getSignedInAccountFromIntent(result.data)
-                Timber.d(task.result.idToken)
-                Timber.d(task.result.email)
                 viewModel.login(task.result.idToken, task.result.email)
             }
         }

--- a/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/LoginFragment.kt
+++ b/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/LoginFragment.kt
@@ -13,7 +13,6 @@ import com.google.android.gms.auth.api.signin.GoogleSignInOptions
 import com.ohdodok.catchytape.core.ui.BaseFragment
 import com.ohdodok.catchytape.feature.login.databinding.FragmentLoginBinding
 import dagger.hilt.android.AndroidEntryPoint
-import timber.log.Timber
 
 @AndroidEntryPoint
 class LoginFragment : BaseFragment<FragmentLoginBinding>(R.layout.fragment_login) {
@@ -22,14 +21,13 @@ class LoginFragment : BaseFragment<FragmentLoginBinding>(R.layout.fragment_login
 
     private val gso = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
         .requestIdToken(BuildConfig.GOOGLE_CLIENT_ID)
-        .requestEmail()
         .build()
 
     private val googleLoginLauncher: ActivityResultLauncher<Intent> =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
             if (result.resultCode == Activity.RESULT_OK) {
                 val task = GoogleSignIn.getSignedInAccountFromIntent(result.data)
-                viewModel.login(task.result.idToken, task.result.email)
+                task.result.idToken?.let { token -> viewModel.login(token) }
             }
         }
 

--- a/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/LoginViewModel.kt
+++ b/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/LoginViewModel.kt
@@ -19,19 +19,15 @@ class LoginViewModel @Inject constructor(
     private val _events = MutableSharedFlow<LoginEvent>()
     val events = _events.asSharedFlow()
 
-    fun login(token: String?, email: String?) {
-        if(token == null || email == null) {
-            return
-        }else{
-            loginUseCase(token)
-                .catch {
-                    _events.emit(LoginEvent.NavigateToNickName(token))
-                }
-                .onEach {
-                    _events.emit(LoginEvent.NavigateToHome)
-                }
-                .launchIn(viewModelScope)
-        }
+    fun login(token: String) {
+        loginUseCase(token)
+            .catch {
+                _events.emit(LoginEvent.NavigateToNickName(token))
+            }
+            .onEach {
+                _events.emit(LoginEvent.NavigateToHome)
+            }
+            .launchIn(viewModelScope)
     }
 }
 

--- a/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/LoginViewModel.kt
+++ b/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/LoginViewModel.kt
@@ -5,14 +5,10 @@ import androidx.lifecycle.viewModelScope
 import com.ohdodok.catchytape.core.domain.usecase.LoginUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.flow.onStart
 import javax.inject.Inject
 
 @HiltViewModel
@@ -20,39 +16,23 @@ class LoginViewModel @Inject constructor(
     private val loginUseCase: LoginUseCase
 ) : ViewModel() {
 
-    private val _uiState: MutableStateFlow<LoginUiState> = MutableStateFlow(LoginUiState.Waiting)
-    val uiState: StateFlow<LoginUiState> = _uiState.asStateFlow()
-
     private val _events = MutableSharedFlow<LoginEvent>()
     val events = _events.asSharedFlow()
 
     fun login(token: String?, email: String?) {
         if(token == null || email == null) {
-            _uiState.value = LoginUiState.Failure
             return
         }else{
             loginUseCase(token)
-                .onStart {
-                    _uiState.value = LoginUiState.Waiting
-                }
                 .catch {
-                    _uiState.value = LoginUiState.Failure
                     _events.emit(LoginEvent.NavigateToNickName(token))
                 }
                 .onEach {
-                    _uiState.value = LoginUiState.Success
                     _events.emit(LoginEvent.NavigateToHome)
                 }
                 .launchIn(viewModelScope)
         }
     }
-}
-
-
-sealed class LoginUiState{
-    data object Waiting : LoginUiState()
-    data object Success : LoginUiState()
-    data object Failure : LoginUiState()
 }
 
 sealed interface LoginEvent {

--- a/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/LoginViewModel.kt
+++ b/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/LoginViewModel.kt
@@ -23,11 +23,9 @@ class LoginViewModel @Inject constructor(
         loginUseCase(token)
             .catch {
                 _events.emit(LoginEvent.NavigateToNickName(token))
-            }
-            .onEach {
+            }.onEach {
                 _events.emit(LoginEvent.NavigateToHome)
-            }
-            .launchIn(viewModelScope)
+            }.launchIn(viewModelScope)
     }
 }
 

--- a/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/LoginViewModel.kt
+++ b/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/LoginViewModel.kt
@@ -37,10 +37,10 @@ class LoginViewModel @Inject constructor(
                 }
                 .catch {
                     _uiState.value = LoginUiState.Failure
-                    _events.emit(LoginEvent.NavigateToNickName)
+                    _events.emit(LoginEvent.NavigateToNickName(token))
                 }
                 .onEach {
-                    _uiState.value = LoginUiState.Success(token = token, email = email)
+                    _uiState.value = LoginUiState.Success
                     _events.emit(LoginEvent.NavigateToHome)
                 }
                 .launchIn(viewModelScope)
@@ -51,11 +51,11 @@ class LoginViewModel @Inject constructor(
 
 sealed class LoginUiState{
     data object Waiting : LoginUiState()
-    data class Success(val token: String, val email: String) : LoginUiState()
+    data object Success : LoginUiState()
     data object Failure : LoginUiState()
 }
 
 sealed interface LoginEvent {
     data object NavigateToHome : LoginEvent
-    data object NavigateToNickName : LoginEvent
+    data class NavigateToNickName(val googleToken: String) : LoginEvent
 }

--- a/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/LoginViewModel.kt
+++ b/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/LoginViewModel.kt
@@ -1,35 +1,60 @@
 package com.ohdodok.catchytape.feature.login
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.ohdodok.catchytape.core.domain.usecase.LoginUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.onStart
+import javax.inject.Inject
 
-class LoginViewModel : ViewModel() {
+@HiltViewModel
+class LoginViewModel @Inject constructor(
+    private val loginUseCase: LoginUseCase
+) : ViewModel() {
 
     private val _uiState: MutableStateFlow<LoginUiState> = MutableStateFlow(LoginUiState.Waiting)
     val uiState: StateFlow<LoginUiState> = _uiState.asStateFlow()
 
-    private val _events: MutableSharedFlow<LoginEvent> = MutableSharedFlow<LoginEvent>()
-    val events: SharedFlow<LoginEvent> = _events.asSharedFlow()
+    private val _events = MutableSharedFlow<LoginEvent>()
+    val events = _events.asSharedFlow()
 
     fun login(token: String?, email: String?) {
-        // 서버 통신 예정
+        if(token == null || email == null) {
+            _uiState.value = LoginUiState.Failure
+            return
+        }else{
+            loginUseCase(token)
+                .onStart {
+                    _uiState.value = LoginUiState.Waiting
+                }
+                .catch {
+                    _uiState.value = LoginUiState.Failure
+                    _events.emit(LoginEvent.NavigateToNickName)
+                }
+                .onEach {
+                    _uiState.value = LoginUiState.Success(token = token, email = email)
+                    _events.emit(LoginEvent.NavigateToHome)
+                }
+                .launchIn(viewModelScope)
+        }
     }
 }
 
 
-// TODO : 서버 연결 후 수정 될 예정
 sealed class LoginUiState{
     data object Waiting : LoginUiState()
-    data object Success : LoginUiState()
+    data class Success(val token: String, val email: String) : LoginUiState()
     data object Failure : LoginUiState()
 }
 
-// TODO : 서버 연결 후 수정 될 예정
 sealed interface LoginEvent {
     data object NavigateToHome : LoginEvent
     data object NavigateToNickName : LoginEvent

--- a/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/NicknameFragment.kt
+++ b/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/NicknameFragment.kt
@@ -1,8 +1,10 @@
 package com.ohdodok.catchytape.feature.login
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
 import com.ohdodok.catchytape.core.ui.BaseFragment
 import com.ohdodok.catchytape.feature.login.databinding.FragmentNicknameBinding
 import dagger.hilt.android.AndroidEntryPoint
@@ -10,14 +12,21 @@ import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
 class NicknameFragment : BaseFragment<FragmentNicknameBinding>(R.layout.fragment_nickname) {
 
+    private val args: NicknameFragmentArgs by navArgs()
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setUpAppbar()
+        setUpStartBtn()
     }
 
     private fun setUpAppbar() {
-        binding.tbNickname.setNavigationOnClickListener {
-            findNavController().popBackStack()
+        setupBackStack(binding.tbNickname)
+    }
+
+    private fun setUpStartBtn() {
+        binding.btnStart.setOnClickListener {
+            activity?.finish()
         }
     }
 }

--- a/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/NicknameFragment.kt
+++ b/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/NicknameFragment.kt
@@ -16,6 +16,8 @@ class NicknameFragment : BaseFragment<FragmentNicknameBinding>(R.layout.fragment
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        binding.viewModel = viewModel
+
         setUpAppbar()
         setUpStartBtn()
         observeEvents()

--- a/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/NicknameFragment.kt
+++ b/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/NicknameFragment.kt
@@ -1,9 +1,8 @@
 package com.ohdodok.catchytape.feature.login
 
-import android.content.Intent
 import android.os.Bundle
 import android.view.View
-import androidx.navigation.fragment.findNavController
+import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.navArgs
 import com.ohdodok.catchytape.core.ui.BaseFragment
 import com.ohdodok.catchytape.feature.login.databinding.FragmentNicknameBinding
@@ -13,11 +12,13 @@ import dagger.hilt.android.AndroidEntryPoint
 class NicknameFragment : BaseFragment<FragmentNicknameBinding>(R.layout.fragment_nickname) {
 
     private val args: NicknameFragmentArgs by navArgs()
+    private val viewModel: NicknameViewModel by viewModels()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setUpAppbar()
         setUpStartBtn()
+        observeEvents()
     }
 
     private fun setUpAppbar() {
@@ -26,7 +27,19 @@ class NicknameFragment : BaseFragment<FragmentNicknameBinding>(R.layout.fragment
 
     private fun setUpStartBtn() {
         binding.btnStart.setOnClickListener {
-            activity?.finish()
+            viewModel.signUp(args.googleToken)
+        }
+    }
+
+    private fun observeEvents() {
+        repeatOnStarted {
+            viewModel.events.collect { event ->
+                when (event) {
+                    is NicknameEvent.NavigateToHome -> {
+                        activity?.finish()
+                    }
+                }
+            }
         }
     }
 }

--- a/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/NicknameViewModel.kt
+++ b/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/NicknameViewModel.kt
@@ -1,0 +1,34 @@
+package com.ohdodok.catchytape.feature.login
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.ohdodok.catchytape.core.domain.usecase.SignUpUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import javax.inject.Inject
+
+@HiltViewModel
+class NicknameViewModel @Inject constructor(
+    private val signUpUseCase: SignUpUseCase
+) : ViewModel() {
+
+    private val _events = MutableSharedFlow<NicknameEvent>()
+    val events = _events.asSharedFlow()
+
+    val nickname = MutableStateFlow("")
+
+    fun signUp(googleToken: String) {
+        signUpUseCase(googleToken, nickname.value)
+            .onEach {
+                _events.emit(NicknameEvent.NavigateToHome)
+            }.launchIn(viewModelScope)
+    }
+}
+
+sealed interface NicknameEvent {
+    data object NavigateToHome : NicknameEvent
+}

--- a/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/NicknameViewModel.kt
+++ b/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/NicknameViewModel.kt
@@ -22,6 +22,7 @@ class NicknameViewModel @Inject constructor(
     val nickname = MutableStateFlow("")
 
     fun signUp(googleToken: String) {
+        // TODO : 중복 검사 및 유효성 검사
         signUpUseCase(googleToken, nickname.value)
             .onEach {
                 _events.emit(NicknameEvent.NavigateToHome)

--- a/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/NicknameViewModel.kt
+++ b/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/NicknameViewModel.kt
@@ -23,7 +23,7 @@ class NicknameViewModel @Inject constructor(
 
     fun signUp(googleToken: String) {
         // TODO : 중복 검사 및 유효성 검사
-        signUpUseCase(googleToken, nickname.value)
+        signUpUseCase(googleToken = googleToken, nickname = nickname.value)
             .onEach {
                 _events.emit(NicknameEvent.NavigateToHome)
             }.launchIn(viewModelScope)

--- a/android/feature/login/src/main/res/layout/fragment_nickname.xml
+++ b/android/feature/login/src/main/res/layout/fragment_nickname.xml
@@ -4,6 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
+
         <variable
             name="viewModel"
             type="com.ohdodok.catchytape.feature.login.NicknameViewModel" />
@@ -41,8 +42,6 @@
             android:layout_width="0dp"
             android:layout_marginTop="@dimen/medium"
             android:hint="@string/nickname"
-            android:inputType="text"
-            app:endIconMode="clear_text"
             android:text="@={viewModel.nickname}"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"

--- a/android/feature/login/src/main/res/layout/fragment_nickname.xml
+++ b/android/feature/login/src/main/res/layout/fragment_nickname.xml
@@ -4,7 +4,9 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
-
+        <variable
+            name="viewModel"
+            type="com.ohdodok.catchytape.feature.login.NicknameViewModel" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -41,6 +43,7 @@
             android:hint="@string/nickname"
             android:inputType="text"
             app:endIconMode="clear_text"
+            android:text="@={viewModel.nickname}"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_nickname_title" />

--- a/android/feature/login/src/main/res/navigation/login_navigation.xml
+++ b/android/feature/login/src/main/res/navigation/login_navigation.xml
@@ -20,6 +20,11 @@
         android:id="@+id/nickname_fragment"
         android:name="com.ohdodok.catchytape.feature.login.NicknameFragment"
         android:label="nickname"
-        tools:layout="@layout/fragment_nickname"/>
+        tools:layout="@layout/fragment_nickname">
+
+        <argument
+            android:name="googleToken"
+            app:argType="string" />
+    </fragment>
 
 </navigation>

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -1,12 +1,12 @@
 [versions]
 agp = "8.1.1"
-core-ktx = "1.9.0"
+androidxCore = "1.9.0"
+androidxAppCompat = "1.6.1"
+androidxDataStore = "1.0.0"
+androidxNavigation = "2.5.3"
 kotlin = "1.9.0"
 
-appcompat = "1.6.1"
 material = "1.9.0"
-
-navigation = "2.5.3"
 
 hilt = "2.48"
 gms = "20.7.0"
@@ -23,12 +23,14 @@ timber = "5.0.1"
 [libraries]
 android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "agp" }
 kotlin-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core-ktx" }
-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
-material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 
-navigation-fragment-ktx = { group = "androidx.navigation", name = "navigation-fragment-ktx", version.ref = "navigation" }
-navigation-ui-ktx = { group = "androidx.navigation", name = "navigation-ui-ktx", version.ref = "navigation" }
+core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "androidxCore" }
+appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "androidxAppCompat" }
+navigation-fragment-ktx = { group = "androidx.navigation", name = "navigation-fragment-ktx", version.ref = "androidxNavigation" }
+navigation-ui-ktx = { group = "androidx.navigation", name = "navigation-ui-ktx", version.ref = "androidxNavigation" }
+datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "androidxDataStore" }
+
+material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
 hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hilt" }
@@ -51,4 +53,4 @@ org-jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.re
 org-jetbrains-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
-navigation-safe-args = { id = "androidx.navigation.safeargs.kotlin", version.ref = "navigation" }
+navigation-safe-args = { id = "androidx.navigation.safeargs.kotlin", version.ref = "androidxNavigation" }

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -9,6 +9,8 @@ kotlin = "1.9.0"
 material = "1.9.0"
 
 hilt = "2.48"
+javaInject = "1"
+
 gms = "20.7.0"
 
 junit = "4.13.2"
@@ -35,6 +37,7 @@ material = { group = "com.google.android.material", name = "material", version.r
 
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
 hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hilt" }
+inject = { group = "javax.inject", name = "javax.inject", version.ref = "javaInject" }
 
 google-play-services = { group = "com.google.android.gms", name = "play-services-auth", version.ref = "gms" }
 

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ retrofit = "2.9.0"
 okhttp = "4.11.0"
 kotlinx-serialization = "1.6.0"
 kotlinx-serialization-converter = "1.0.0"
+coroutines = "1.3.5"
 
 timber = "5.0.1"
 
@@ -43,6 +44,7 @@ retrofit = { module = "com.squareup.retrofit2:retrofit", name = "retrofit", vers
 okhttp-logging-interceptor = { module = "com.squareup.okhttp3:logging-interceptor", name = "okhttp", version.ref = "okhttp" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 kotlinx-serialization-converter = { module = "com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter", version.ref = "kotlinx-serialization-converter" }
+coroutines = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
 
 timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
 


### PR DESCRIPTION
## Issue
- #90 

## Overview
- (data 모듈) Preference DataStore 추가
- (domain 모듈) 코루틴, inject 추가
- http 접근 허용하도록 Manifest 에 usesCleartextTraffic 설정 [참고문서](https://gun0912.tistory.com/80)
- local.properties에 server url 저장
- 로그인, 회원가입 로직
<img width="500" src="https://github.com/boostcampwm2023/and04-catchy-tape/assets/62279741/67a8e280-f2b2-434b-814f-4964523144c9" />
<img width="800" src="https://github.com/boostcampwm2023/and04-catchy-tape/assets/62279741/3bacb5b8-ba12-4587-bf7f-8ada5e266342" />


## Screenshot
https://github.com/boostcampwm2023/and04-catchy-tape/assets/62279741/08619e78-5d30-4445-b2ff-0780fd6201e2

## To Reviewers 
- 네트워크 에러 처리방식이 아직 정리가 안되서 이부분은 이슈로 따로 빼서 공통적으로 처리할 방법을 논의했으면 좋겠습니당
- 지금 diff 가 400 줄이 넘어서 멈추고 PR 날립니당 🥲
- preference 쪽은 #56 분이 이어서 해주시면 될 것 같습니다. 
