### PR TITLE
Android Release APK 배포 자동화

### DIFF
--- a/.github/workflows/android-cd.yml
+++ b/.github/workflows/android-cd.yml
@@ -1,0 +1,52 @@
+name: Android CD
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+defaults:
+  run:
+    working-directory: ./android
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'corretto'
+          java-version: 17
+
+      - name: Create Properties File
+        env:
+          DEBUG_KEYSTORE: ${{ secrets.DEBUG_KEYSTORE }}
+          KEYSTORE_PROPERTIES: ${{ secrets.KEYSTORE_PROPERTIES }}
+          LOCAL_PROPERTIES: ${{ secrets.LOCAL_PROPERTIES }}
+        run: |
+          echo "$DEBUG_KEYSTORE" | base64 -d > debug.keystore
+          echo "$KEYSTORE_PROPERTIES" > keystore.properties
+          echo "$LOCAL_PROPERTIES" > local.properties
+
+      - name: Build Release APK
+        run: |
+          ./gradlew :app:assembleRelease
+
+      - name: Upload Release Build to Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: release-artifacts
+          path: ./android/app/build/outputs/apk/release/
+          if-no-files-found: error
+
+      - name: Create Github Release
+        uses: softprops/action-gh-release@v1
+        with:
+          generate_release_notes: true
+          files: |
+            ./android/app/build/outputs/apk/release/*.apk

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -37,6 +37,7 @@ android {
 
     buildTypes {
         release {
+            signingConfig = signingConfigs.getByName("debug")
             isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),


### PR DESCRIPTION
## Issue
- #87 

## Overview
- release apk 에 서명 포함    [공식문서](https://developer.android.com/build/building-cmdline)
- 태그를 푸쉬하면,  apk 파일을 빌드하고 apk 파일을 release하는 워크플로우 구축

## Screenshot 
개인 레포에서 테스트 한 Screenshot  입니당

<img width="816" alt="image" src="https://github.com/boostcampwm2023/and04-catchy-tape/assets/62279741/0b3fd258-beb9-43b4-8e55-e5fe62a905bd">


