### PR TITLE
자동 로그인

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
         android:usesCleartextTraffic="true"
         android:theme="@style/Theme.CatchyTape">
         <activity
-            android:name=".MainActivity"
+            android:name=".feature.login.LoginActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -20,6 +20,14 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
+        </activity>
+
+
     </application>
 
 </manifest>

--- a/android/app/src/main/java/com/ohdodok/catchytape/CtApplication.kt
+++ b/android/app/src/main/java/com/ohdodok/catchytape/CtApplication.kt
@@ -10,6 +10,14 @@ class CtApplication : Application() {
         super.onCreate()
         if (BuildConfig.DEBUG) {
             Timber.plant(object : Timber.DebugTree() {
+                override fun d(message: String?, vararg args: Any?) {
+                    if (message != null && message.isEmpty()) {
+                        super.d(getString(R.string.timber_blank_string), *args)
+                    } else {
+                        super.d(message, *args)
+                    }
+                }
+
                 override fun createStackElementTag(element: StackTraceElement): String {
                     return String.format(
                         getString(R.string.timber_log_format),

--- a/android/app/src/main/java/com/ohdodok/catchytape/MainActivity.kt
+++ b/android/app/src/main/java/com/ohdodok/catchytape/MainActivity.kt
@@ -1,9 +1,7 @@
 package com.ohdodok.catchytape
 
-import android.content.Intent
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
-import com.ohdodok.catchytape.feature.login.LoginActivity
+import androidx.appcompat.app.AppCompatActivity
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -11,9 +9,5 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
-
-        // TODO : 자동로그인 할 때 수정 필요
-        val intent = Intent(this, LoginActivity::class.java)
-        startActivity(intent)
     }
 }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <resources>
     <string name="app_name">Catchy Tape</string>
     <string name="timber_log_format">C: %s, L: %s</string>
+    <string name="timber_blank_string">"BLANK("")"</string>
 </resources>

--- a/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/repository/AuthRepositoryImpl.kt
+++ b/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/repository/AuthRepositoryImpl.kt
@@ -26,6 +26,7 @@ class AuthRepositoryImpl @Inject constructor(
         val response = userApi.login(LoginRequest(idToken = googleToken))
         if (response.isSuccessful) {
             response.body()?.let { loginResponse ->
+                saveIdToken(googleToken)
                 emit(loginResponse.accessToken)
             }
         } else if (response.code() == 401) {

--- a/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/repository/AuthRepository.kt
+++ b/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/repository/AuthRepository.kt
@@ -8,6 +8,10 @@ interface AuthRepository {
 
     fun signUpWithGoogle(googleToken: String, nickname: String): Flow<String>
 
-    suspend fun saveToken(token: String)
+    suspend fun saveAccessToken(token: String)
+
+    suspend fun saveIdToken(token: String)
+
+    suspend fun getIdToken(): String
 
 }

--- a/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/usecase/GetIdTokenUseCase.kt
+++ b/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/usecase/GetIdTokenUseCase.kt
@@ -3,7 +3,7 @@ package com.ohdodok.catchytape.core.domain.usecase
 import com.ohdodok.catchytape.core.domain.repository.AuthRepository
 import javax.inject.Inject
 
-class TokenUseCase @Inject constructor(
+class GetIdTokenUseCase @Inject constructor(
     private val authRepository: AuthRepository
 ) {
     suspend operator fun invoke() = authRepository.getIdToken()

--- a/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/usecase/LoginUseCase.kt
+++ b/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/usecase/LoginUseCase.kt
@@ -10,5 +10,5 @@ class LoginUseCase @Inject constructor(
 ) {
 
     operator fun invoke(googleToken: String): Flow<Unit> =
-        authRepository.loginWithGoogle(googleToken).map { authRepository.saveToken(it) }
+        authRepository.loginWithGoogle(googleToken).map { authRepository.saveAccessToken(it) }
 }

--- a/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/usecase/SignUpUseCase.kt
+++ b/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/usecase/SignUpUseCase.kt
@@ -10,6 +10,6 @@ class SignUpUseCase @Inject constructor(
 ) {
 
     operator fun invoke(googleToken: String, nickname: String): Flow<Unit> =
-        authRepository.signUpWithGoogle(googleToken, nickname).map { authRepository.saveToken(it) }
+        authRepository.signUpWithGoogle(googleToken, nickname).map { authRepository.saveAccessToken(it) }
 
 }

--- a/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/usecase/TokenUseCase.kt
+++ b/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/usecase/TokenUseCase.kt
@@ -1,0 +1,10 @@
+package com.ohdodok.catchytape.core.domain.usecase
+
+import com.ohdodok.catchytape.core.domain.repository.AuthRepository
+import javax.inject.Inject
+
+class TokenUseCase @Inject constructor(
+    private val authRepository: AuthRepository
+) {
+    suspend operator fun invoke() = authRepository.getIdToken()
+}

--- a/android/core/ui/src/main/java/com/ohdodok/catchytape/core/ui/BaseFragment.kt
+++ b/android/core/ui/src/main/java/com/ohdodok/catchytape/core/ui/BaseFragment.kt
@@ -15,7 +15,6 @@ import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.appbar.MaterialToolbar
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 
 abstract class BaseFragment<VB : ViewDataBinding>(
@@ -52,11 +51,4 @@ abstract class BaseFragment<VB : ViewDataBinding>(
         }
     }
 
-    fun <T> collectFlow(flow: Flow<T>, action: suspend (T) -> Unit) {
-        viewLifecycleOwner.lifecycleScope.launch {
-            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                flow.collect(action)
-            }
-        }
-    }
 }

--- a/android/core/ui/src/main/java/com/ohdodok/catchytape/core/ui/BaseFragment.kt
+++ b/android/core/ui/src/main/java/com/ohdodok/catchytape/core/ui/BaseFragment.kt
@@ -15,6 +15,7 @@ import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.appbar.MaterialToolbar
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 
 abstract class BaseFragment<VB : ViewDataBinding>(
@@ -48,6 +49,14 @@ abstract class BaseFragment<VB : ViewDataBinding>(
     fun LifecycleOwner.repeatOnStarted(block: suspend CoroutineScope.() -> Unit) {
         viewLifecycleOwner.lifecycleScope.launch {
             lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED, block)
+        }
+    }
+
+    fun <T> collectFlow(flow: Flow<T>, action: suspend (T) -> Unit) {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                flow.collect(action)
+            }
         }
     }
 }

--- a/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/LoginActivity.kt
+++ b/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/LoginActivity.kt
@@ -15,13 +15,13 @@ class LoginActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_login)
-        viewModel.autoLoginWithIdToken()
+        viewModel.automaticallyLogin()
 
         val content: View = findViewById(android.R.id.content)
         content.viewTreeObserver.addOnPreDrawListener(
             object : ViewTreeObserver.OnPreDrawListener {
                 override fun onPreDraw(): Boolean {
-                    if (viewModel.isAutoLoginFinish) {
+                    if (viewModel.isAutoLoginFinished) {
                         content.viewTreeObserver.removeOnPreDrawListener(this)
                         return true
                     } else {

--- a/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/LoginActivity.kt
+++ b/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/LoginActivity.kt
@@ -1,12 +1,21 @@
 package com.ohdodok.catchytape.feature.login
 
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.view.View
+import android.view.ViewTreeObserver
+import androidx.activity.viewModels
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 
 
 @AndroidEntryPoint
 class LoginActivity : AppCompatActivity() {
+    private val viewModel: LoginViewModel by viewModels()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_login)

--- a/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/LoginActivity.kt
+++ b/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/LoginActivity.kt
@@ -5,35 +5,23 @@ import android.view.View
 import android.view.ViewTreeObserver
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.launch
 
 
 @AndroidEntryPoint
 class LoginActivity : AppCompatActivity() {
     private val viewModel: LoginViewModel by viewModels()
 
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_login)
-        var isSplashFinishReady = false
         viewModel.autoLoginWithIdToken()
 
         val content: View = findViewById(android.R.id.content)
         content.viewTreeObserver.addOnPreDrawListener(
             object : ViewTreeObserver.OnPreDrawListener {
                 override fun onPreDraw(): Boolean {
-                    lifecycleScope.launch {
-                        repeatOnLifecycle(Lifecycle.State.STARTED) {
-                            viewModel.isAutoLoginFinish.collect { isSplashFinishReady = it }
-                        }
-                    }
-
-                    if (isSplashFinishReady) {
+                    if (viewModel.isAutoLoginFinish) {
                         content.viewTreeObserver.removeOnPreDrawListener(this)
                         return true
                     } else {

--- a/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/LoginActivity.kt
+++ b/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/LoginActivity.kt
@@ -16,8 +16,33 @@ import kotlinx.coroutines.launch
 class LoginActivity : AppCompatActivity() {
     private val viewModel: LoginViewModel by viewModels()
 
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_login)
+        var isSplashFinishReady = false
+        viewModel.autoLoginWithIdToken()
+
+        val content: View = findViewById(android.R.id.content)
+        content.viewTreeObserver.addOnPreDrawListener(
+            object : ViewTreeObserver.OnPreDrawListener {
+                override fun onPreDraw(): Boolean {
+                    lifecycleScope.launch {
+                        repeatOnLifecycle(Lifecycle.State.STARTED) {
+                            viewModel.isAutoLoginFinish.collect { isSplashFinishReady = it }
+                        }
+                    }
+
+                    if (isSplashFinishReady) {
+                        content.viewTreeObserver.removeOnPreDrawListener(this)
+                        return true
+                    } else {
+                        return false
+                    }
+                }
+            }
+        )
     }
 }
+
+

--- a/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/LoginFragment.kt
+++ b/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/LoginFragment.kt
@@ -51,25 +51,27 @@ class LoginFragment : BaseFragment<FragmentLoginBinding>(R.layout.fragment_login
     }
 
     private fun observeEvents() {
-        collectFlow(viewModel.events) { handleUiEvent(it) }
+        repeatOnStarted {
+            viewModel.events.collect { event ->
+                when (event) {
+                    is LoginEvent.NavigateToHome -> {
+                        val intent = Intent()
+                        intent.component = ComponentName("com.ohdodok.catchytape", "com.ohdodok.catchytape.MainActivity")
+                        startActivity(intent)
+                        loginActivity.finish()
+                    }
+
+                    is LoginEvent.NavigateToNickName -> {
+                        findNavController().navigate(
+                            LoginFragmentDirections.actionLoginFragmentToNicknameFragment(
+                                googleToken = event.googleToken
+                            )
+                        )
+                    }
+                }
+            }
+        }
     }
 
-
-    private fun handleUiEvent(event: LoginEvent) = when (event) {
-        is LoginEvent.NavigateToHome -> {
-            val intent = Intent()
-            intent.component = ComponentName("com.ohdodok.catchytape", "com.ohdodok.catchytape.MainActivity")
-            startActivity(intent)
-            loginActivity.finish()
-        }
-
-        is LoginEvent.NavigateToNickName -> {
-            findNavController().navigate(
-                LoginFragmentDirections.actionLoginFragmentToNicknameFragment(
-                    googleToken = event.googleToken
-                )
-            )
-        }
-    }
 
 }

--- a/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/LoginFragment.kt
+++ b/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/LoginFragment.kt
@@ -1,12 +1,13 @@
 package com.ohdodok.catchytape.feature.login
 
 import android.app.Activity
+import android.content.ComponentName
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.fragment.app.viewModels
+import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions
@@ -14,10 +15,13 @@ import com.ohdodok.catchytape.core.ui.BaseFragment
 import com.ohdodok.catchytape.feature.login.databinding.FragmentLoginBinding
 import dagger.hilt.android.AndroidEntryPoint
 
+
 @AndroidEntryPoint
 class LoginFragment : BaseFragment<FragmentLoginBinding>(R.layout.fragment_login) {
 
-    private val viewModel: LoginViewModel by viewModels()
+    private val viewModel: LoginViewModel by activityViewModels()
+
+    private val loginActivity by lazy { activity as LoginActivity }
 
     private val gso = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
         .requestIdToken(BuildConfig.GOOGLE_CLIENT_ID)
@@ -47,22 +51,25 @@ class LoginFragment : BaseFragment<FragmentLoginBinding>(R.layout.fragment_login
     }
 
     private fun observeEvents() {
-        repeatOnStarted {
-            viewModel.events.collect { event ->
-                when (event) {
-                    is LoginEvent.NavigateToHome -> {
-                        activity?.finish()
-                    }
+        collectFlow(viewModel.events) { handleUiEvent(it) }
+    }
 
-                    is LoginEvent.NavigateToNickName -> {
-                        findNavController().navigate(
-                            LoginFragmentDirections.actionLoginFragmentToNicknameFragment(
-                                googleToken = event.googleToken
-                            )
-                        )
-                    }
-                }
-            }
+
+    private fun handleUiEvent(event: LoginEvent) = when (event) {
+        is LoginEvent.NavigateToHome -> {
+            val intent = Intent()
+            intent.component = ComponentName("com.ohdodok.catchytape", "com.ohdodok.catchytape.MainActivity")
+            startActivity(intent)
+            loginActivity.finish()
+        }
+
+        is LoginEvent.NavigateToNickName -> {
+            findNavController().navigate(
+                LoginFragmentDirections.actionLoginFragmentToNicknameFragment(
+                    googleToken = event.googleToken
+                )
+            )
         }
     }
+
 }

--- a/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/LoginViewModel.kt
+++ b/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/LoginViewModel.kt
@@ -24,8 +24,9 @@ class LoginViewModel @Inject constructor(
     private val _events = MutableSharedFlow<LoginEvent>()
     val events = _events.asSharedFlow()
 
-    private val _isAutoLoginFinish = MutableSharedFlow<Boolean>()
-    val isAutoLoginFinish = _isAutoLoginFinish.asSharedFlow()
+    private var _isAutoLoginFinish = false
+    val isAutoLoginFinish get() = _isAutoLoginFinish
+
 
     fun login(token: String, isAutoLogin: Boolean = false) {
         loginUseCase(token)
@@ -46,7 +47,7 @@ class LoginViewModel @Inject constructor(
                 login(idToken, true)
             }
             delay(1000)
-            _isAutoLoginFinish.emit(true)
+            _isAutoLoginFinish = true
         }
     }
 

--- a/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/LoginViewModel.kt
+++ b/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/LoginViewModel.kt
@@ -2,8 +2,8 @@ package com.ohdodok.catchytape.feature.login
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.ohdodok.catchytape.core.domain.usecase.GetIdTokenUseCase
 import com.ohdodok.catchytape.core.domain.usecase.LoginUseCase
-import com.ohdodok.catchytape.core.domain.usecase.TokenUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -17,15 +17,15 @@ import javax.inject.Inject
 @HiltViewModel
 class LoginViewModel @Inject constructor(
     private val loginUseCase: LoginUseCase,
-    private val tokenUseCase: TokenUseCase
+    private val tokenUseCase: GetIdTokenUseCase
 
 ) : ViewModel() {
 
     private val _events = MutableSharedFlow<LoginEvent>()
     val events = _events.asSharedFlow()
 
-    private var _isAutoLoginFinish = false
-    val isAutoLoginFinish get() = _isAutoLoginFinish
+    var isAutoLoginFinish: Boolean = false
+        private set
 
 
     fun login(token: String, isAutoLogin: Boolean = false) {
@@ -47,7 +47,7 @@ class LoginViewModel @Inject constructor(
                 login(idToken, true)
             }
             delay(1000)
-            _isAutoLoginFinish = true
+            isAutoLoginFinish = true
         }
     }
 

--- a/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/LoginViewModel.kt
+++ b/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/LoginViewModel.kt
@@ -24,7 +24,7 @@ class LoginViewModel @Inject constructor(
     private val _events = MutableSharedFlow<LoginEvent>()
     val events = _events.asSharedFlow()
 
-    var isAutoLoginFinish: Boolean = false
+    var isAutoLoginFinished: Boolean = false
         private set
 
 
@@ -40,14 +40,14 @@ class LoginViewModel @Inject constructor(
     }
 
 
-    fun autoLoginWithIdToken() {
+    fun automaticallyLogin() {
         viewModelScope.launch {
             val idToken = tokenUseCase()
             if (idToken.isNotEmpty()) {
                 login(idToken, true)
             }
             delay(1000)
-            isAutoLoginFinish = true
+            isAutoLoginFinished = true
         }
     }
 

--- a/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/LoginViewModel.kt
+++ b/android/feature/login/src/main/java/com/ohdodok/catchytape/feature/login/LoginViewModel.kt
@@ -3,30 +3,53 @@ package com.ohdodok.catchytape.feature.login
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ohdodok.catchytape.core.domain.usecase.LoginUseCase
+import com.ohdodok.catchytape.core.domain.usecase.TokenUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class LoginViewModel @Inject constructor(
-    private val loginUseCase: LoginUseCase
+    private val loginUseCase: LoginUseCase,
+    private val tokenUseCase: TokenUseCase
+
 ) : ViewModel() {
 
     private val _events = MutableSharedFlow<LoginEvent>()
     val events = _events.asSharedFlow()
 
-    fun login(token: String) {
+    private val _isAutoLoginFinish = MutableSharedFlow<Boolean>()
+    val isAutoLoginFinish = _isAutoLoginFinish.asSharedFlow()
+
+    fun login(token: String, isAutoLogin: Boolean = false) {
         loginUseCase(token)
             .catch {
-                _events.emit(LoginEvent.NavigateToNickName(token))
+                if (isAutoLogin.not()) {
+                    _events.emit(LoginEvent.NavigateToNickName(token))
+                }
             }.onEach {
                 _events.emit(LoginEvent.NavigateToHome)
             }.launchIn(viewModelScope)
     }
+
+
+    fun autoLoginWithIdToken() {
+        viewModelScope.launch {
+            val idToken = tokenUseCase()
+            if (idToken.isNotEmpty()) {
+                login(idToken, true)
+            }
+            delay(1000)
+            _isAutoLoginFinish.emit(true)
+        }
+    }
+
 }
 
 sealed interface LoginEvent {

--- a/android/feature/upload/src/main/java/com/ohdodok/catchytape/feature/upload/BindingAdapter.kt
+++ b/android/feature/upload/src/main/java/com/ohdodok/catchytape/feature/upload/BindingAdapter.kt
@@ -1,4 +1,4 @@
-package com.ohdodok.catchytape.core.ui.bindingadapter
+package com.ohdodok.catchytape.feature.upload
 
 import android.widget.AutoCompleteTextView
 import androidx.databinding.BindingAdapter


### PR DESCRIPTION
## Issue
- #56

## Overview
- 기본적으로, LoginActiviy (앱 시작점) -> MainActivity 형식으로 구현
  - MainActivity이 시작점이면, onCreate시 Home 화면을 불러와야 하는데, 가입이 안되어있을 경우, accessToken이 없기 때문에 Home 화면의 데이터를 얻는 과정에서 예외 처리가 많이 필요할 것 같아서 LoginActiviy (앱 시작점) -> MainActivity 형식 을 선택


- 현재 서버 api 및 로그인 과정이 `accessToken`이 아닌`idToken` 으로 유효성 검증하기 때문에, saveIdToken, saveAccessToken로 세분화 하고, login과 signup이 성공시 saveIdToken으로 pref에 `idToken` 저장
   -  추후 서버에서 accessToken 검증 api 제공시에, 변경 예정

0. LoginActiviy onCreate 시, Splash를 그리는 과정에서 getIdToken을 호출
1. idToken 값이 ""(공백) 이다 -> LoginActivity 그대로 시작
2. "~~~~~~"(존재한다)
     2.1 -> idToken 값이 유효한지 서버 통신한다.
            2.1.1 검사 결과 유효 안한다. -> LoginActivity 그대로 시작
            2.1.2 검사 결과 유효 한다. -> LoginActivity 종료 후, MainActivity 시작 
(Login은 app 모듈에 있는 Main을 모를 수 밖에 없음으로, `intent.component` 사용,  이를 위해 MainActivity에 `android:exported="true"` 추가)

- 이 과정에서 delay(1000)를 임의로 하였는데, 그 이유는, splah 화면 -> MainActivity 으로 가기전에 delay를 주어야만, LoginActivity 화면이 보이지 않게됨. (delay를 주지 않으면, 아주 LoginActivity 화면이 잠깐 보임) 


## Others
- BaseFragment에 `collectFlow` 제네릭 함수 구현 및 observeEvents 변경 ( 기존 함수 indent가 깊어서, handleUiEvent만 하는 기능을 하는 함수를 따로 뺌)
- timber로 log를 출력할때, "" (공백) 은 logcat에 출력이 아예 안되기 때문에, timber `override fun d`로 `BLANK("")` 을 출력하게 하였습니다.
  - 현재 issue에 맞지는 않지만, 따로 브랜치 파고 pr 따로 남기기 애매해서, 여기서 pr에서 commit후 push 했습니다.


## ScreenShot
<img width="300" src="https://github.com/boostcampwm2023/and04-catchy-tape/assets/59787852/ebe9f3b7-0dd4-435a-86e8-a89939361a37" />
