### PR TITLE
Kotest CI result 업로드

### DIFF
--- a/.github/workflows/android-pull-request-ci.yml
+++ b/.github/workflows/android-pull-request-ci.yml
@@ -39,7 +39,7 @@ jobs:
           echo "$DEBUG_KEYSTORE" | base64 -d > debug.keystore
           echo "$KEYSTORE_PROPERTIES" > keystore.properties
           echo "$LOCAL_PROPERTIES" > local.properties
-          ./gradlew testDebugUnitTest --stacktrace
+          ./gradlew test --stacktrace
 
       - name: Publish Test Results
         if: always()

--- a/.github/workflows/android-pull-request-ci.yml
+++ b/.github/workflows/android-pull-request-ci.yml
@@ -39,7 +39,7 @@ jobs:
           echo "$DEBUG_KEYSTORE" | base64 -d > debug.keystore
           echo "$KEYSTORE_PROPERTIES" > keystore.properties
           echo "$LOCAL_PROPERTIES" > local.properties
-          ./gradlew test --stacktrace
+          ./gradlew debug-unit-test --stacktrace
 
       - name: Publish Test Results
         if: always()

--- a/.github/workflows/android-pull-request-ci.yml
+++ b/.github/workflows/android-pull-request-ci.yml
@@ -39,7 +39,7 @@ jobs:
           echo "$DEBUG_KEYSTORE" | base64 -d > debug.keystore
           echo "$KEYSTORE_PROPERTIES" > keystore.properties
           echo "$LOCAL_PROPERTIES" > local.properties
-          ./gradlew debug-unit-test --stacktrace
+          ./gradlew debugUnitTest --stacktrace
 
       - name: Publish Test Results
         if: always()

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -10,12 +10,4 @@ plugins {
     alias(libs.plugins.navigation.safe.args) apply false
 }
 
-tasks.register<Test>("test") {
-    useJUnitPlatform()
-    reports {
-        junitXml.required.set(false)
-    }
-    systemProperty("gradle.build.dir", project.buildDir)
-}
-
 true // Needed to make the Suppress annotation work for the plugins block

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -10,4 +10,16 @@ plugins {
     alias(libs.plugins.navigation.safe.args) apply false
 }
 
+
+tasks.register<Exec>("domain-unit-test") {
+    commandLine = listOf("gradle", "core:domain:test")
+}
+
+
+tasks.register<Exec>("debug-unit-test") {
+    dependsOn("domain-unit-test")
+    commandLine = listOf("gradle", "testDebugUnitTest")
+}
+
+
 true // Needed to make the Suppress annotation work for the plugins block

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -11,13 +11,13 @@ plugins {
 }
 
 
-tasks.register<Exec>("domain-unit-test") {
+tasks.register<Exec>("domainUnitTest") {
     commandLine = listOf("gradle", "core:domain:test")
 }
 
 
-tasks.register<Exec>("debug-unit-test") {
-    dependsOn("domain-unit-test")
+tasks.register<Exec>("debugUnitTest") {
+    dependsOn("domainUnitTest")
     commandLine = listOf("gradle", "testDebugUnitTest")
 }
 

--- a/android/core/domain/build.gradle.kts
+++ b/android/core/domain/build.gradle.kts
@@ -7,6 +7,14 @@ tasks.withType<Test>().configureEach {
     useJUnitPlatform()
 }
 
+tasks.getByName<Test>("test") {
+    useJUnitPlatform()
+    reports {
+        junitXml.required.set(false)
+    }
+    systemProperty("gradle.build.dir", project.buildDir)
+}
+
 dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.kotest.runner)

--- a/android/core/domain/src/test/java/com/ohdodok/catchytape/core/domain/KoTestConfig.kt
+++ b/android/core/domain/src/test/java/com/ohdodok/catchytape/core/domain/KoTestConfig.kt
@@ -1,10 +1,10 @@
-package com.ohdodok.catchytape.core.domain.signup
+package com.ohdodok.catchytape.core.domain
 
 import io.kotest.core.config.AbstractProjectConfig
 import io.kotest.core.extensions.Extension
 import io.kotest.extensions.junitxml.JunitXmlReporter
 
-class TestConfig : AbstractProjectConfig() {
+class KoTestConfig : AbstractProjectConfig() {
 
     override fun extensions(): List<Extension> = listOf(
         JunitXmlReporter(

--- a/android/core/domain/src/test/java/com/ohdodok/catchytape/core/domain/SampleTest.kt
+++ b/android/core/domain/src/test/java/com/ohdodok/catchytape/core/domain/SampleTest.kt
@@ -1,15 +1,20 @@
 package com.ohdodok.catchytape.core.domain
 
-import io.kotest.core.spec.style.StringSpec
+import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 
-class SampleTest : StringSpec({
-    "Strings" {
-        "length는 문자열의 길이를 반환해야 한다" {
-            "hello".length shouldBe 5
-        }
+class SampleTest : FunSpec({
+
+    test("test sample 1") {
+        1 + 2 shouldBe 3
     }
-    "중첩 하지 않아도 됨" {
-        "hello".length shouldBe 5
+
+    test("test sample 2") {
+        3 + 4 shouldBe 7
     }
+
+    test("test sample 3") {
+        3 + 4 shouldBe 10
+    }
+
 })

--- a/android/core/domain/src/test/java/com/ohdodok/catchytape/core/domain/SampleTest.kt
+++ b/android/core/domain/src/test/java/com/ohdodok/catchytape/core/domain/SampleTest.kt
@@ -1,0 +1,15 @@
+package com.ohdodok.catchytape.core.domain
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class SampleTest : StringSpec({
+    "Strings" {
+        "length는 문자열의 길이를 반환해야 한다" {
+            "hello".length shouldBe 5
+        }
+    }
+    "중첩 하지 않아도 됨" {
+        "hello".length shouldBe 5
+    }
+})

--- a/android/core/domain/src/test/java/com/ohdodok/catchytape/core/domain/SampleTest.kt
+++ b/android/core/domain/src/test/java/com/ohdodok/catchytape/core/domain/SampleTest.kt
@@ -14,7 +14,7 @@ class SampleTest : FunSpec({
     }
 
     test("test sample 3") {
-        3 + 4 shouldBe 10
+        3 + 7 shouldBe 10
     }
 
 })

--- a/android/core/domain/src/test/java/com/ohdodok/catchytape/core/domain/signup/TestConfig.kt
+++ b/android/core/domain/src/test/java/com/ohdodok/catchytape/core/domain/signup/TestConfig.kt
@@ -10,7 +10,7 @@ class TestConfig : AbstractProjectConfig() {
         JunitXmlReporter(
             includeContainers = false, // don't write out status for all tests
             useTestPathAsName = true, // use the full test path (ie, includes parent test names)
-            outputDir = "test-results/excludeContainers"
+            outputDir = "../build/test-results"
         )
     )
 }


### PR DESCRIPTION
## Issue
- #118 

## Overview
- Kotest에서도 단위 테스트 보고서를 업로드하도록 설정
- TestConfig path를 적절한 경로로 변경
- project 수준의 build.gradle.kts이 아닌 모듈에다가 task를 설정했어야 했다.


- testDebugUnitTest 로는 Domain 모듈을 인식 할 수 없으므로, root gradle에 domain:test 하는 Task 추가