### PR TITLE
사용자 검증 API, 탈퇴 API 구현

### DIFF
--- a/server/src/auth/auth.controller.ts
+++ b/server/src/auth/auth.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
   HttpCode,
   Post,
@@ -13,6 +14,7 @@ import { AuthService } from './auth.service';
 import { HTTP_STATUS_CODE } from 'src/httpStatusCode.enum';
 import { UserCreateDto } from 'src/dto/userCreate.dto';
 import { AuthGuard } from '@nestjs/passport';
+import { User } from 'src/entity/user.entity';
 
 @Controller('users')
 export class AuthController {
@@ -38,8 +40,17 @@ export class AuthController {
 
   @Get('verify')
   @UseGuards(AuthGuard())
+  @HttpCode(HTTP_STATUS_CODE.SUCCESS)
   verifyToken(@Req() req): { userId: string } {
-    const user = req.user;
+    const user: User = req.user;
     return { userId: user.user_id };
+  }
+
+  @Delete()
+  @UseGuards(AuthGuard())
+  @HttpCode(HTTP_STATUS_CODE.SUCCESS)
+  async deleteUser(@Req() req): Promise<{userId: string}> {
+    const user: User = req.user;
+    return await this.authService.deleteUser(user);
   }
 }

--- a/server/src/auth/auth.controller.ts
+++ b/server/src/auth/auth.controller.ts
@@ -1,14 +1,18 @@
 import {
   Body,
   Controller,
+  Get,
   HttpCode,
   Post,
+  Req,
+  UseGuards,
   UsePipes,
   ValidationPipe,
 } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { HTTP_STATUS_CODE } from 'src/httpStatusCode.enum';
 import { UserCreateDto } from 'src/dto/userCreate.dto';
+import { AuthGuard } from '@nestjs/passport';
 
 @Controller('users')
 export class AuthController {
@@ -30,5 +34,12 @@ export class AuthController {
     @Body() userCreateDto: UserCreateDto,
   ): Promise<{ accessToken: string }> {
     return this.authService.signup(userCreateDto);
+  }
+
+  @Get('verify')
+  @UseGuards(AuthGuard())
+  verifyToken(@Req() req): { userId: string } {
+    const user = req.user;
+    return { userId: user.user_id };
   }
 }

--- a/server/src/auth/auth.service.ts
+++ b/server/src/auth/auth.service.ts
@@ -78,4 +78,9 @@ export class AuthService {
       return true;
     }
   }
+
+  async deleteUser(user: User): Promise<{ userId: string }> {
+    await this.userRepository.delete(user.user_id);
+    return { userId: user.user_id };
+  }
 }


### PR DESCRIPTION
## Issue
- #132 

## Overview
* `GET` `/users/verify` 로 사용자 검증. (헤더에 JWT 토큰 필요)
  -> 성공시 200, userId 응답

* `DELETE` `/users` 로 사용자 탈퇴. (헤더에 JWT 토큰 필요)
  -> 성공시 200, userId 응답

## Screenshot (optional)
- 검증  API
<img width="1392" alt="image" src="https://github.com/boostcampwm2023/and04-catchy-tape/assets/84065420/ae27f0af-1d49-4d25-8551-b28391dc00b6">

- 탈퇴 API
<img width="1392" alt="image" src="https://github.com/boostcampwm2023/and04-catchy-tape/assets/84065420/d1e212ba-5f54-484b-914b-db9cd93433ef">

