### PR TITLE
Presigned URL 활용한 업로드

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -40,6 +40,7 @@
         "@types/passport": "^1.0.15",
         "@types/passport-google-oauth20": "^2.0.14",
         "@types/supertest": "^2.0.12",
+        "@types/uuid": "^9.0.7",
         "@typescript-eslint/eslint-plugin": "^6.0.0",
         "@typescript-eslint/parser": "^6.0.0",
         "eslint": "^8.42.0",
@@ -2232,6 +2233,12 @@
       "dependencies": {
         "@types/superagent": "*"
       }
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.7.tgz",
+      "integrity": "sha512-WUtIVRUZ9i5dYXefDEAI7sh9/O7jGvHg7Df/5O/gtH3Yabe5odI3UWopVR1qbPXQtvOxWu3mM4XxlYeZtMWF4g==",
+      "dev": true
     },
     "node_modules/@types/validator": {
       "version": "13.11.6",

--- a/server/package.json
+++ b/server/package.json
@@ -51,6 +51,7 @@
     "@types/passport": "^1.0.15",
     "@types/passport-google-oauth20": "^2.0.14",
     "@types/supertest": "^2.0.12",
+    "@types/uuid": "^9.0.7",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
     "eslint": "^8.42.0",

--- a/server/src/config/ncloud.config.ts
+++ b/server/src/config/ncloud.config.ts
@@ -14,6 +14,7 @@ export class NcloudConfigService {
         accessKeyId: this.configService.get<string>('ACCESS_ID'),
         secretAccessKey: this.configService.get<string>('SECRET_ACCESS_KEY'),
       },
+      signatureVersion: 'v4',
     });
   }
 }

--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -15,3 +15,9 @@ export enum Genres {
 }
 
 export const fileExt = ['jpeg', 'jpg', 'png', 'mp3'];
+
+export const pathPattern = [
+  /^image\/user\/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/,
+  /^image\/cover\/\d+$/,
+  /^music\/\d+$/,
+];

--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -13,3 +13,5 @@ export enum Genres {
   'dance' = 'dance',
   'etc' = 'etc',
 }
+
+export const fileExt = ['jpeg', 'jpg', 'png', 'mp3'];

--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -1,6 +1,6 @@
 export const fileSize: Record<string, number> = {
-  MUSIC_FILE_LIMIT_SIZE: 1024 * 1024 * 50,
-  IMAGE_FILE_LIMIT_SIZE: 1024 * 1024 * 5,
+  MUSIC_SIZE: 1024 * 1024 * 50,
+  IMAGE_SIZE: 1024 * 1024 * 5,
 };
 
 export enum Genres {
@@ -14,10 +14,12 @@ export enum Genres {
   'etc' = 'etc',
 }
 
-export const fileExt = ['jpeg', 'jpg', 'png', 'mp3'];
+export const keyFlags = ['user', 'music', 'cover'];
 
-export const pathPattern = [
-  /^image\/user\/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/,
-  /^image\/cover\/\d+$/,
-  /^music\/\d+$/,
-];
+export const keyHandler: {
+  [key: string]: (uuid: string) => string;
+} = {
+  user: (uuid) => `image/user/${uuid}/user.png`,
+  music: (uuid) => `music/${uuid}/music.mp3`,
+  cover: (uuid) => `image/cover/${uuid}/cover.png`,
+};

--- a/server/src/upload/upload.controller.ts
+++ b/server/src/upload/upload.controller.ts
@@ -1,52 +1,28 @@
-import {
-  Controller,
-  Post,
-  UploadedFile,
-  UseInterceptors,
-  ParseFilePipe,
-  MaxFileSizeValidator,
-  FileTypeValidator,
-} from '@nestjs/common';
+import { Controller, Get, Query, HttpCode } from '@nestjs/common';
 import { UploadService } from './upload.service';
 import { HTTP_STATUS_CODE } from 'src/httpStatusCode.enum';
-import { FileInterceptor } from '@nestjs/platform-express';
-import { fileSize } from 'src/constants';
 
 @Controller('upload')
 export class UploadController {
   constructor(private uploadService: UploadService) {}
 
-  @Post('/music')
-  @UseInterceptors(FileInterceptor('file'))
-  async uploadMusic(
-    @UploadedFile(
-      new ParseFilePipe({
-        validators: [
-          new MaxFileSizeValidator({ maxSize: fileSize.MUSIC_FILE_LIMIT_SIZE }),
-          new FileTypeValidator({ fileType: 'audio/mpeg' }),
-        ],
-      }),
-    )
-    file: Express.Multer.File,
-  ): Promise<{ url: string }> {
-    const { url } = await this.uploadService.uploadMusic(file);
-    return { url };
-  }
+  @Get()
+  @HttpCode(HTTP_STATUS_CODE.SUCCESS)
+  async getSignedURL(
+    @Query('path') path: string,
+    @Query('fileName') fileName: string,
+    @Query('ext') ext: string,
+  ): Promise<{ signedUrl: string }> {
+    try {
+      const signedUrl = await this.uploadService.getSignedURL(
+        path,
+        fileName,
+        ext,
+      );
 
-  @Post('/image')
-  @UseInterceptors(FileInterceptor('file'))
-  async uploadImage(
-    @UploadedFile(
-      new ParseFilePipe({
-        validators: [
-          new MaxFileSizeValidator({ maxSize: fileSize.IMAGE_FILE_LIMIT_SIZE }),
-          new FileTypeValidator({ fileType: 'image/jpeg' }),
-        ],
-      }),
-    )
-    file: Express.Multer.File,
-  ): Promise<{ url: string }> {
-    const { url } = await this.uploadService.uploadImage(file);
-    return { url };
+      return { signedUrl };
+    } catch (error) {
+      throw error;
+    }
   }
 }

--- a/server/src/upload/upload.controller.ts
+++ b/server/src/upload/upload.controller.ts
@@ -1,24 +1,46 @@
-import { Controller, Get, Query, HttpCode } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Req,
+  Query,
+  HttpCode,
+  UseGuards,
+  HttpException,
+} from '@nestjs/common';
 import { UploadService } from './upload.service';
 import { HTTP_STATUS_CODE } from 'src/httpStatusCode.enum';
+import { AuthGuard } from '@nestjs/passport';
+import { v4 } from 'uuid';
 
 @Controller('upload')
 export class UploadController {
   constructor(private uploadService: UploadService) {}
 
+  @Get('uuid')
+  @UseGuards(AuthGuard())
+  @HttpCode(HTTP_STATUS_CODE.SUCCESS)
+  getMusicUUID(): { uuid: string } {
+    try {
+      return { uuid: v4() };
+    } catch (err) {
+      console.log(err);
+      throw new HttpException('SERVER ERROR', HTTP_STATUS_CODE.SERVER_ERROR);
+    }
+  }
+
   @Get()
+  @UseGuards(AuthGuard())
   @HttpCode(HTTP_STATUS_CODE.SUCCESS)
   async getSignedURL(
-    @Query('path') path: string,
-    @Query('fileName') fileName: string,
-    @Query('ext') ext: string,
+    @Query('type') type: string,
+    @Query('uuid') uuid: string,
+    @Req() req,
   ): Promise<{ signedUrl: string }> {
     try {
-      const signedUrl = await this.uploadService.getSignedURL(
-        path,
-        fileName,
-        ext,
-      );
+      const userId = req.user.user_id;
+      const id = type === 'user' ? userId : uuid;
+
+      const signedUrl = await this.uploadService.getSignedURL(type, id);
 
       return { signedUrl };
     } catch (error) {

--- a/server/src/upload/upload.module.ts
+++ b/server/src/upload/upload.module.ts
@@ -3,9 +3,10 @@ import { UploadController } from './upload.controller';
 import { UploadService } from './upload.service';
 import { NcloudConfigService } from 'src/config/ncloud.config';
 import { HttpModule } from '@nestjs/axios';
+import { AuthModule } from 'src/auth/auth.module';
 
 @Module({
-  imports: [HttpModule],
+  imports: [HttpModule, AuthModule],
   controllers: [UploadController],
   providers: [UploadService, NcloudConfigService],
 })

--- a/server/src/upload/upload.module.ts
+++ b/server/src/upload/upload.module.ts
@@ -2,8 +2,10 @@ import { Module } from '@nestjs/common';
 import { UploadController } from './upload.controller';
 import { UploadService } from './upload.service';
 import { NcloudConfigService } from 'src/config/ncloud.config';
+import { HttpModule } from '@nestjs/axios';
 
 @Module({
+  imports: [HttpModule],
   controllers: [UploadController],
   providers: [UploadService, NcloudConfigService],
 })

--- a/server/src/upload/upload.service.ts
+++ b/server/src/upload/upload.service.ts
@@ -2,8 +2,7 @@ import { HttpException, Injectable } from '@nestjs/common';
 import { HTTP_STATUS_CODE } from 'src/httpStatusCode.enum';
 import { NcloudConfigService } from './../config/ncloud.config';
 import { S3 } from 'aws-sdk';
-import { fileExt } from './../constants';
-import { pathPattern } from './../constants';
+import { fileSize, keyFlags, keyHandler } from './../constants';
 
 @Injectable()
 export class UploadService {
@@ -12,39 +11,25 @@ export class UploadService {
     this.objectStorage = nCloudConfigService.createObjectStorageOption();
   }
 
-  private isValidPath(path: string, fileName: string) {
-    for (let i = 0; i < pathPattern.length; i++) {
-      if (pathPattern[i].test(path)) {
-        if (i < 2) return true;
-        if (i == 2 && fileName.length <= 50) return true;
-      }
-    }
+  private isValidFlag(flag: string): boolean {
+    if (keyFlags.includes(flag)) return true;
 
     return false;
   }
 
-  private isValidExt(ext: string) {
-    if (fileExt.includes(ext)) return true;
-
-    return false;
-  }
-
-  async getSignedURL(
-    keyPath: string,
-    fileName: string,
-    ext: string,
-  ): Promise<string> {
+  async getSignedURL(flag: string, uuid: string): Promise<string> {
     try {
-      if (!this.isValidPath(keyPath, fileName) || !this.isValidExt(ext))
-        throw new HttpException('BAD REQUEST', HTTP_STATUS_CODE.BAD_REQUEST);
+      if (!this.isValidFlag(flag))
+        throw new HttpException('BAD_REQUEST', HTTP_STATUS_CODE.BAD_REQUEST);
 
-      const url = await this.objectStorage.getSignedUrlPromise('putObject', {
+      const keyPath = keyHandler[flag](uuid);
+
+      return await this.objectStorage.getSignedUrlPromise('putObject', {
         Bucket: 'catchy-tape-bucket2',
-        Key: `${keyPath}/${fileName}.${ext}`,
-        Expires: 60,
+        Key: `${keyPath}`,
+        Expires: 600,
+        ACL: 'public-read',
       });
-
-      return url;
     } catch (error) {
       if (error instanceof HttpException) throw error;
 

--- a/server/src/upload/upload.service.ts
+++ b/server/src/upload/upload.service.ts
@@ -12,10 +12,11 @@ export class UploadService {
     this.objectStorage = nCloudConfigService.createObjectStorageOption();
   }
 
-  private isValidPath(path: string) {
+  private isValidPath(path: string, fileName: string) {
     for (let i = 0; i < pathPattern.length; i++) {
       if (pathPattern[i].test(path)) {
-        return true;
+        if (i < 2) return true;
+        if (i == 2 && fileName.length <= 50) return true;
       }
     }
 
@@ -34,7 +35,7 @@ export class UploadService {
     ext: string,
   ): Promise<string> {
     try {
-      if (!this.isValidPath(keyPath) || !this.isValidExt(ext))
+      if (!this.isValidPath(keyPath, fileName) || !this.isValidExt(ext))
         throw new HttpException('BAD REQUEST', HTTP_STATUS_CODE.BAD_REQUEST);
 
       const url = await this.objectStorage.getSignedUrlPromise('putObject', {

--- a/server/src/upload/upload.service.ts
+++ b/server/src/upload/upload.service.ts
@@ -2,44 +2,48 @@ import { HttpException, Injectable } from '@nestjs/common';
 import { HTTP_STATUS_CODE } from 'src/httpStatusCode.enum';
 import { NcloudConfigService } from './../config/ncloud.config';
 import { S3 } from 'aws-sdk';
-import { Readable } from 'stream';
+import { fileExt } from './../constants';
 
 @Injectable()
 export class UploadService {
-  private readonly objectStorage: S3;
-
+  private objectStorage: S3;
   constructor(private readonly nCloudConfigService: NcloudConfigService) {
     this.objectStorage = nCloudConfigService.createObjectStorageOption();
   }
 
-  async uploadMusic(file: Express.Multer.File): Promise<{ url: string }> {
-    try {
-      const uploadResult = await this.objectStorage
-        .upload({
-          Bucket: 'catchy-tape-bucket2',
-          Key: `music/original/${file.originalname}`,
-          Body: Readable.from(file.buffer),
-        })
-        .promise();
+  private isValidPath(path: string) {
+    if (path.startsWith('image/user/')) return true;
+    if (path.startsWith('image/cover/')) return true;
+    if (path.startsWith('music/')) return true;
 
-      return { url: uploadResult.Location };
-    } catch {
-      throw new HttpException('SERVER ERROR', HTTP_STATUS_CODE.SERVER_ERROR);
-    }
+    return false;
   }
 
-  async uploadImage(file: Express.Multer.File): Promise<{ url: string }> {
-    try {
-      const uploadResult = await this.objectStorage
-        .upload({
-          Bucket: 'catchy-tape-bucket2',
-          Key: `image/${file.originalname}`,
-          Body: Readable.from(file.buffer),
-        })
-        .promise();
+  private isValidExt(ext: string) {
+    if (fileExt.includes(ext)) return true;
 
-      return { url: uploadResult.Location };
-    } catch {
+    return false;
+  }
+
+  async getSignedURL(
+    keyPath: string,
+    fileName: string,
+    ext: string,
+  ): Promise<string> {
+    try {
+      if (!this.isValidPath(keyPath) || !this.isValidExt(ext))
+        throw new HttpException('BAD REQUEST', HTTP_STATUS_CODE.BAD_REQUEST);
+
+      const url = await this.objectStorage.getSignedUrlPromise('putObject', {
+        Bucket: 'catchy-tape-bucket2',
+        Key: `${keyPath}/${fileName}.${ext}`,
+        Expires: 60,
+      });
+
+      return url;
+    } catch (error) {
+      if (error instanceof HttpException) throw error;
+
       throw new HttpException('SERVER ERROR', HTTP_STATUS_CODE.SERVER_ERROR);
     }
   }

--- a/server/src/upload/upload.service.ts
+++ b/server/src/upload/upload.service.ts
@@ -3,6 +3,7 @@ import { HTTP_STATUS_CODE } from 'src/httpStatusCode.enum';
 import { NcloudConfigService } from './../config/ncloud.config';
 import { S3 } from 'aws-sdk';
 import { fileExt } from './../constants';
+import { pathPattern } from './../constants';
 
 @Injectable()
 export class UploadService {
@@ -12,9 +13,11 @@ export class UploadService {
   }
 
   private isValidPath(path: string) {
-    if (path.startsWith('image/user/')) return true;
-    if (path.startsWith('image/cover/')) return true;
-    if (path.startsWith('music/')) return true;
+    for (let i = 0; i < pathPattern.length; i++) {
+      if (pathPattern[i].test(path)) {
+        return true;
+      }
+    }
 
     return false;
   }


### PR DESCRIPTION
## Issue
- #124 

## Overview
- 클라이언트가 `/upload?path=아래 세 개의 경로 중 하나형태&fileName=파일이름&ext=확장자` 로 요청(GET)
=> Presigned URL 반환
=> 이후 URL에 **PUT** 요청(binary 형태의 file)을 보내면 업로드 성공!

** 바뀐 로직
1. 업로드 화면으로 들어갈 때 서버에 한 번 요청을 보냄 → 서버는 uuid 값을 반환
2-1. 클라에서 음악 업로드를 하고 싶으면 {type: music, uuid: uuid} 로 요청을 보냄 → 서버에서 /music/{uuid}/music.mp3 의 presigned url 을 응답 → 클라이언트에서 해당 url 로 음악 업로드
2-2. 음악 cover(사진) 업로드를 하고 싶으면 {type: cover, uuid: uuid} 로 요청을 보냄 → 서버에서 /image/cover/{uuid}/cover.png 의 presigned url 응답 → 클라이언트에서 해당 url 로 커버 사진 업로드

- 다만 문제가 많습니다 🥲 (코드를 짜는게 아니라 생각하느라 오래 걸린 것 같네요ㅠㅠ)
1. 버킷 비공개 전환 시 추가해야 하는 인증 헤더 코드가 잘 작동되지 않아 현재 **버킷은 매우 public한 상태**
2.  같은 경로의 중복된 이름은 최근 파일로 덮어씌워집니다....

## Screenshot
- 음악/이미지 업로드
![image](https://github.com/boostcampwm2023/and04-catchy-tape/assets/83707411/9ea7f370-d4f2-42ad-9bda-9370be516bf6)

- 잘못된 uuid 입력 시
![image](https://github.com/boostcampwm2023/and04-catchy-tape/assets/83707411/f74068a2-2b04-41ce-8aa7-1b85b5dbadae)

- user 정보 없을 시
![image](https://github.com/boostcampwm2023/and04-catchy-tape/assets/83707411/b67c5bfb-8b8e-429f-a3e6-c1eaf5918c0f)

![image](https://github.com/boostcampwm2023/and04-catchy-tape/assets/83707411/b67c5bfb-8b8e-429f-a3e6-c1eaf5918c0f)


