### PR TITLE
플레이리스트 조회 API

### DIFF
--- a/server/src/entity/music_playlist.entity.ts
+++ b/server/src/entity/music_playlist.entity.ts
@@ -1,4 +1,10 @@
-import { BaseEntity, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import {
+  BaseEntity,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
 import { Music } from './music.entity';
 import { Playlist } from './playlist.entity';
 
@@ -8,10 +14,35 @@ export class Music_Playlist extends BaseEntity {
   music_playlist_id: number;
 
   @ManyToOne(() => Music, (music) => music.music_playlist)
-  @JoinColumn({name: 'music_id'})
-  music: Music
+  @JoinColumn({ name: 'music_id' })
+  music: Music;
 
   @ManyToOne(() => Playlist, (playlist) => playlist.music_playlist)
-  @JoinColumn({name: 'playlist_id'})
-  playlist: Playlist
+  @JoinColumn({ name: 'playlist_id' })
+  playlist: Playlist;
+
+  static async getMusicListByPlaylistId(playlistId: number): Promise<Music[]> {
+    return this.find({
+      relations: {
+        music: { user: true },
+      },
+      where: {
+        playlist: { playlist_Id: playlistId },
+      },
+      select: {
+        music: {
+          musicId: true,
+          title: true,
+          cover: true,
+          musicFile: true,
+          genre: true,
+          user: { user_id: true, nickname: true },
+        },
+        music_playlist_id: false,
+      },
+      order: {
+        music_playlist_id: 'DESC',
+      },
+    }).then((a: Music_Playlist[]) => a.map((b) => b.music));
+  }
 }

--- a/server/src/entity/playlist.entity.ts
+++ b/server/src/entity/playlist.entity.ts
@@ -31,4 +31,16 @@ export class Playlist extends BaseEntity {
 
   @OneToMany(() => Music_Playlist, (music_playlist) => music_playlist.playlist)
   music_playlist: Music_Playlist[];
+
+  static async getPlaylistsByUserId(userId: string): Promise<Playlist[]> {
+    return this.find({
+      select: { playlist_Id: true, playlist_title: true },
+      where: {
+        user: { user_id: userId },
+      },
+      order: {
+        updated_at: 'DESC',
+      },
+    });
+  }
 }

--- a/server/src/playlist/playlist.controller.ts
+++ b/server/src/playlist/playlist.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  Get,
   HttpCode,
   Param,
   Post,
@@ -13,6 +14,7 @@ import { PlaylistService } from './playlist.service';
 import { AuthGuard } from '@nestjs/passport';
 import { HTTP_STATUS_CODE } from 'src/httpStatusCode.enum';
 import { PlaylistCreateDto } from 'src/dto/playlistCreate.dto';
+import { Playlist } from 'src/entity/playlist.entity';
 
 @Controller('playlists')
 export class PlaylistController {
@@ -50,5 +52,15 @@ export class PlaylistController {
         musicId,
       );
     return { music_playlist_id: music_playlist_id };
+  }
+
+  @Get()
+  @UseGuards(AuthGuard())
+  @HttpCode(HTTP_STATUS_CODE.SUCCESS)
+  async getUserPlaylists(@Req() req) {
+    const userId: string = req.user.user_id;
+    const playlists: Playlist[] =
+      await this.playlistService.getUserPlaylists(userId);
+    return playlists;
   }
 }

--- a/server/src/playlist/playlist.controller.ts
+++ b/server/src/playlist/playlist.controller.ts
@@ -15,6 +15,7 @@ import { AuthGuard } from '@nestjs/passport';
 import { HTTP_STATUS_CODE } from 'src/httpStatusCode.enum';
 import { PlaylistCreateDto } from 'src/dto/playlistCreate.dto';
 import { Playlist } from 'src/entity/playlist.entity';
+import { Music } from 'src/entity/music.entity';
 
 @Controller('playlists')
 export class PlaylistController {
@@ -57,10 +58,21 @@ export class PlaylistController {
   @Get()
   @UseGuards(AuthGuard())
   @HttpCode(HTTP_STATUS_CODE.SUCCESS)
-  async getUserPlaylists(@Req() req) {
+  async getUserPlaylists(@Req() req): Promise<Playlist[]> {
     const userId: string = req.user.user_id;
     const playlists: Playlist[] =
       await this.playlistService.getUserPlaylists(userId);
     return playlists;
+  }
+
+  @Get(':playlistId')
+  @UseGuards(AuthGuard())
+  @HttpCode(HTTP_STATUS_CODE.SUCCESS)
+  async getPlaylistMusics(
+    @Req() req,
+    @Param('playlistId') playlistId: number,
+  ): Promise<Music[]> {
+    const userId: string = req.user.user_id;
+    return await this.playlistService.getPlaylistMusics(userId, playlistId);
   }
 }

--- a/server/src/playlist/playlist.service.ts
+++ b/server/src/playlist/playlist.service.ts
@@ -52,6 +52,11 @@ export class PlaylistService {
       throw new HttpException('NOT_EXIST_MUSIC', HTTP_STATUS_CODE.BAD_REQUEST);
     }
 
+    // 이미 추가된 음악인지 확인
+    if (await this.isAlreadyAdded(playlistId, musicId)) {
+      throw new HttpException('ALREADY_ADDED', HTTP_STATUS_CODE.BAD_REQUEST);
+    }
+
     // 관계테이블에 추가
     const new_music_playlist: Music_Playlist =
       this.music_playlistRepository.create({
@@ -63,6 +68,14 @@ export class PlaylistService {
       await this.music_playlistRepository.save(new_music_playlist);
     this.setUpdatedAtNow(playlistId);
     return result.music_playlist_id;
+  }
+
+  async isAlreadyAdded(playlistId: number, musicId: number): Promise<boolean> {
+    const count: number = await this.music_playlistRepository.countBy({
+      music: { musicId: musicId },
+      playlist: { playlist_Id: playlistId },
+    });
+    return count !== 0;
   }
 
   async isExistPlaylistOnUser(

--- a/server/src/playlist/playlist.service.ts
+++ b/server/src/playlist/playlist.service.ts
@@ -61,6 +61,7 @@ export class PlaylistService {
 
     const result: Music_Playlist =
       await this.music_playlistRepository.save(new_music_playlist);
+    this.setUpdatedAtNow(playlistId);
     return result.music_playlist_id;
   }
 
@@ -81,6 +82,14 @@ export class PlaylistService {
     });
 
     return musicCount !== 0;
+  }
+
+  async setUpdatedAtNow(playlistId: number): Promise<void> {
+    const targetPlaylist: Playlist = await this.playlistRepository.findOne({
+      where: { playlist_Id: playlistId },
+    });
+    targetPlaylist.updated_at = new Date();
+    this.playlistRepository.save(targetPlaylist);
   }
 
   async getUserPlaylists(userId: string): Promise<Playlist[]> {

--- a/server/src/playlist/playlist.service.ts
+++ b/server/src/playlist/playlist.service.ts
@@ -22,17 +22,21 @@ export class PlaylistService {
     userId: string,
     playlistCreateDto: PlaylistCreateDto,
   ): Promise<number> {
-    const title: string = playlistCreateDto.title;
-    const newPlaylist: Playlist = this.playlistRepository.create({
-      playlist_title: title,
-      created_at: new Date(),
-      updated_at: new Date(),
-      user: { user_id: userId },
-    });
+    try {
+      const title: string = playlistCreateDto.title;
+      const newPlaylist: Playlist = this.playlistRepository.create({
+        playlist_title: title,
+        created_at: new Date(),
+        updated_at: new Date(),
+        user: { user_id: userId },
+      });
 
-    const result: Playlist = await this.playlistRepository.save(newPlaylist);
-    const playlistId: number = result.playlist_Id;
-    return playlistId;
+      const result: Playlist = await this.playlistRepository.save(newPlaylist);
+      const playlistId: number = result.playlist_Id;
+      return playlistId;
+    } catch {
+      throw new HttpException('SERVER_ERROR', HTTP_STATUS_CODE.SERVER_ERROR);
+    }
   }
 
   async addMusicToPlaylist(
@@ -58,55 +62,79 @@ export class PlaylistService {
     }
 
     // 관계테이블에 추가
-    const new_music_playlist: Music_Playlist =
-      this.music_playlistRepository.create({
-        music: { musicId: musicId },
-        playlist: { playlist_Id: playlistId },
-      });
+    try {
+      const new_music_playlist: Music_Playlist =
+        this.music_playlistRepository.create({
+          music: { musicId: musicId },
+          playlist: { playlist_Id: playlistId },
+        });
 
-    const result: Music_Playlist =
-      await this.music_playlistRepository.save(new_music_playlist);
-    this.setUpdatedAtNow(playlistId);
-    return result.music_playlist_id;
+      const result: Music_Playlist =
+        await this.music_playlistRepository.save(new_music_playlist);
+      this.setUpdatedAtNow(playlistId);
+      return result.music_playlist_id;
+    } catch {
+      throw new HttpException('SERVER_ERROR', HTTP_STATUS_CODE.SERVER_ERROR);
+    }
   }
 
   async isAlreadyAdded(playlistId: number, musicId: number): Promise<boolean> {
-    const count: number = await this.music_playlistRepository.countBy({
-      music: { musicId: musicId },
-      playlist: { playlist_Id: playlistId },
-    });
-    return count !== 0;
+    try {
+      const count: number = await this.music_playlistRepository.countBy({
+        music: { musicId: musicId },
+        playlist: { playlist_Id: playlistId },
+      });
+      return count !== 0;
+    } catch {
+      throw new HttpException('SERVER_ERROR', HTTP_STATUS_CODE.SERVER_ERROR);
+    }
   }
 
   async isExistPlaylistOnUser(
     playlistId: number,
     userId: string,
   ): Promise<boolean> {
-    const playlistCount: number = await this.playlistRepository.countBy({
-      playlist_Id: playlistId,
-      user: { user_id: userId },
-    });
-    return playlistCount !== 0;
+    try {
+      const playlistCount: number = await this.playlistRepository.countBy({
+        playlist_Id: playlistId,
+        user: { user_id: userId },
+      });
+      return playlistCount !== 0;
+    } catch {
+      throw new HttpException('SERVER_ERROR', HTTP_STATUS_CODE.SERVER_ERROR);
+    }
   }
 
   async isExistMusic(musicId: number): Promise<boolean> {
-    const musicCount: number = await this.MusicRepository.countBy({
-      musicId: musicId,
-    });
+    try {
+      const musicCount: number = await this.MusicRepository.countBy({
+        musicId: musicId,
+      });
 
-    return musicCount !== 0;
+      return musicCount !== 0;
+    } catch {
+      throw new HttpException('SERVER_ERROR', HTTP_STATUS_CODE.SERVER_ERROR);
+    }
   }
 
   async setUpdatedAtNow(playlistId: number): Promise<void> {
-    const targetPlaylist: Playlist = await this.playlistRepository.findOne({
-      where: { playlist_Id: playlistId },
-    });
-    targetPlaylist.updated_at = new Date();
-    this.playlistRepository.save(targetPlaylist);
+    try {
+      const targetPlaylist: Playlist = await this.playlistRepository.findOne({
+        where: { playlist_Id: playlistId },
+      });
+      targetPlaylist.updated_at = new Date();
+      this.playlistRepository.save(targetPlaylist);
+    } catch {
+      throw new HttpException('SERVER_ERROR', HTTP_STATUS_CODE.SERVER_ERROR);
+    }
   }
 
   async getUserPlaylists(userId: string): Promise<Playlist[]> {
-    return Playlist.getPlaylistsByUserId(userId);
+    try {
+      return Playlist.getPlaylistsByUserId(userId);
+    } catch {
+      throw new HttpException('SERVER_ERROR', HTTP_STATUS_CODE.SERVER_ERROR);
+    }
   }
 
   async getPlaylistMusics(
@@ -119,6 +147,10 @@ export class PlaylistService {
         HTTP_STATUS_CODE.BAD_REQUEST,
       );
     }
-    return Music_Playlist.getMusicListByPlaylistId(playlistId);
+    try {
+      return Music_Playlist.getMusicListByPlaylistId(playlistId);
+    } catch {
+      throw new HttpException('SERVER_ERROR', HTTP_STATUS_CODE.SERVER_ERROR);
+    }
   }
 }

--- a/server/src/playlist/playlist.service.ts
+++ b/server/src/playlist/playlist.service.ts
@@ -82,4 +82,18 @@ export class PlaylistService {
 
     return musicCount !== 0;
   }
+
+  async getUserPlaylists(userId: string): Promise<Playlist[]> {
+    const playlists: Playlist[] = await this.playlistRepository.find({
+      select: { playlist_Id: true, playlist_title: true },
+      where: {
+        user: { user_id: userId },
+      },
+      order: {
+        updated_at: 'ASC',
+      },
+    });
+
+    return playlists;
+  }
 }

--- a/server/src/playlist/playlist.service.ts
+++ b/server/src/playlist/playlist.service.ts
@@ -112,10 +112,49 @@ export class PlaylistService {
         user: { user_id: userId },
       },
       order: {
-        updated_at: 'ASC',
+        updated_at: 'DESC',
       },
     });
 
     return playlists;
+  }
+
+  async getPlaylistMusics(
+    userId: string,
+    playlistId: number,
+  ): Promise<Music[]> {
+    if (!(await this.isExistPlaylistOnUser(playlistId, userId))) {
+      throw new HttpException(
+        'NOT_EXIST_PLAYLIST_ON_USER',
+        HTTP_STATUS_CODE.BAD_REQUEST,
+      );
+    }
+
+    const musics: Music[] = await this.music_playlistRepository
+      .find({
+        relations: {
+          music: { user: true },
+        },
+        where: {
+          playlist: { playlist_Id: playlistId },
+        },
+        select: {
+          music: {
+            musicId: true,
+            title: true,
+            cover: true,
+            musicFile: true,
+            genre: true,
+            user: { user_id: true, nickname: true },
+          },
+          music_playlist_id: false,
+        },
+        order: {
+          music_playlist_id: 'DESC',
+        },
+      })
+      .then((a: Music_Playlist[]) => a.map((b) => b.music));
+
+    return musics;
   }
 }

--- a/server/src/playlist/playlist.service.ts
+++ b/server/src/playlist/playlist.service.ts
@@ -106,17 +106,7 @@ export class PlaylistService {
   }
 
   async getUserPlaylists(userId: string): Promise<Playlist[]> {
-    const playlists: Playlist[] = await this.playlistRepository.find({
-      select: { playlist_Id: true, playlist_title: true },
-      where: {
-        user: { user_id: userId },
-      },
-      order: {
-        updated_at: 'DESC',
-      },
-    });
-
-    return playlists;
+    return Playlist.getPlaylistsByUserId(userId);
   }
 
   async getPlaylistMusics(
@@ -129,32 +119,6 @@ export class PlaylistService {
         HTTP_STATUS_CODE.BAD_REQUEST,
       );
     }
-
-    const musics: Music[] = await this.music_playlistRepository
-      .find({
-        relations: {
-          music: { user: true },
-        },
-        where: {
-          playlist: { playlist_Id: playlistId },
-        },
-        select: {
-          music: {
-            musicId: true,
-            title: true,
-            cover: true,
-            musicFile: true,
-            genre: true,
-            user: { user_id: true, nickname: true },
-          },
-          music_playlist_id: false,
-        },
-        order: {
-          music_playlist_id: 'DESC',
-        },
-      })
-      .then((a: Music_Playlist[]) => a.map((b) => b.music));
-
-    return musics;
+    return Music_Playlist.getMusicListByPlaylistId(playlistId);
   }
 }


### PR DESCRIPTION
## Issue
- #36 

## Overview
- **`GET` `/playlists` 플레이리스트 조회**
- **`GET` `/playlists/{playlistId}` 플레이리스트에 들어있는 음악 조회**
- 응답은 Swagger 참고

- 플레이리스트에 이미 추가된 음악을 추가 요청했을 때 `400` `ALREADY_ADDED` 응답

## Screenshot
- **`GET` `/playlists` 플레이리스트 조회**
<img width="1348" alt="스크린샷 2023-11-23 오전 2 10 38" src="https://github.com/boostcampwm2023/and04-catchy-tape/assets/84065420/e78e546a-9c83-4d87-826b-fa162dddf170">

- **플레이리스트에 이미 추가된 음악을 추가 요청했을 때**
<img width="1392" alt="스크린샷 2023-11-23 오전 2 54 40" src="https://github.com/boostcampwm2023/and04-catchy-tape/assets/84065420/1934a897-44b4-4096-9178-07d17845c9d8">

- **`GET` `/playlists/{playlistId}` 플레이리스트에 들어있는 음악 조회**
<img width="1392" alt="스크린샷 2023-11-23 오전 4 18 11" src="https://github.com/boostcampwm2023/and04-catchy-tape/assets/84065420/443e5c6d-72c2-4b9a-b0e5-5f66fed001f2">

## To Reviewers
service 에서 DB 에 접근하는 로직이 길어져서 가독성을 망친다고 생각해 **Active Record 패턴**을 적용해서 Entity 내에 DB 접근 로직을 넣었습니다. service 계층에서 조금이라도 가독성이 망가진다면 **Active Record 패턴**을 적극적으로 사용하는 것이 좋을 것 같다고 생각합니다!
[참고자료](https://imsoncod.tistory.com/m/40)