### PR TITLE
토큰 데이터 스토어 계층 분리

### DIFF
--- a/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/di/RepositoryModule.kt
+++ b/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/di/RepositoryModule.kt
@@ -3,9 +3,11 @@ package com.ohdodok.catchytape.core.data.di
 import com.ohdodok.catchytape.core.data.repository.AuthRepositoryImpl
 import com.ohdodok.catchytape.core.data.repository.MusicRepositoryImpl
 import com.ohdodok.catchytape.core.data.repository.UrlRepositoryImpl
+import com.ohdodok.catchytape.core.data.repository.UserTokenRepositoryImpl
 import com.ohdodok.catchytape.core.domain.repository.AuthRepository
 import com.ohdodok.catchytape.core.domain.repository.MusicRepository
 import com.ohdodok.catchytape.core.domain.repository.UrlRepository
+import com.ohdodok.catchytape.core.domain.repository.UserTokenRepository
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -22,9 +24,14 @@ interface RepositoryModule {
 
     @Binds
     @Singleton
+    fun bindUserTokenRepository(userTokenRepositoryImpl: UserTokenRepositoryImpl): UserTokenRepository
+
+    @Binds
+    @Singleton
     fun bindMusicRepository(musicRepositoryImpl: MusicRepositoryImpl): MusicRepository
 
     @Binds
     @Singleton
     fun bindUrlRepository(urlRepositoryImpl: UrlRepositoryImpl): UrlRepository
+
 }

--- a/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/repository/AuthRepositoryImpl.kt
+++ b/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/repository/AuthRepositoryImpl.kt
@@ -1,7 +1,6 @@
 package com.ohdodok.catchytape.core.data.repository
 
 import com.ohdodok.catchytape.core.data.api.UserApi
-import com.ohdodok.catchytape.core.data.datasource.TokenLocalDataSource
 import com.ohdodok.catchytape.core.data.model.LoginRequest
 import com.ohdodok.catchytape.core.data.model.SignUpRequest
 import com.ohdodok.catchytape.core.domain.repository.AuthRepository
@@ -11,7 +10,6 @@ import javax.inject.Inject
 
 class AuthRepositoryImpl @Inject constructor(
     private val userApi: UserApi,
-    private val tokenDataSource: TokenLocalDataSource,
 ) : AuthRepository {
 
     override fun loginWithGoogle(googleToken: String): Flow<String> = flow {
@@ -31,10 +29,6 @@ class AuthRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun saveAccessToken(token: String) {
-        tokenDataSource.saveAccessToken(token)
-    }
-
     override fun isDuplicatedNickname(nickname: String): Flow<Boolean> = flow {
         val response = userApi.verifyDuplicatedNickname(nickname = nickname)
 
@@ -45,11 +39,8 @@ class AuthRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun tryLoginAutomatically(): Boolean {
-        val accessToken = tokenDataSource.getAccessToken()
-
-        if (accessToken.isBlank()) return false
-
-        return userApi.verify("Bearer $accessToken").isSuccessful
+    override suspend fun verifyToken(token: String): Boolean {
+        return userApi.verify("Bearer ${token}").isSuccessful
     }
+
 }

--- a/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/repository/UserTokenRepositoryImpl.kt
+++ b/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/repository/UserTokenRepositoryImpl.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 class UserTokenRepositoryImpl @Inject constructor(
-    private val dataStore: DataStore<Preferences>
+    private val dataStore: DataStore<Preferences>,
 ) : UserTokenRepository {
 
     private val accessTokenKey = stringPreferencesKey("accessToken")
@@ -21,4 +21,5 @@ class UserTokenRepositoryImpl @Inject constructor(
     override suspend fun saveAccessToken(token: String) {
         dataStore.edit { preferences -> preferences[accessTokenKey] = token }
     }
+
 }

--- a/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/repository/UserTokenRepositoryImpl.kt
+++ b/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/repository/UserTokenRepositoryImpl.kt
@@ -1,0 +1,24 @@
+package com.ohdodok.catchytape.core.data.repository
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.ohdodok.catchytape.core.domain.repository.UserTokenRepository
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class UserTokenRepositoryImpl @Inject constructor(
+    private val dataStore: DataStore<Preferences>
+) : UserTokenRepository {
+
+    private val accessTokenKey = stringPreferencesKey("accessToken")
+
+    override suspend fun getAccessToken(): String =
+        dataStore.data.map { preferences -> preferences[accessTokenKey] ?: "" }.first()
+
+    override suspend fun saveAccessToken(token: String) {
+        dataStore.edit { preferences -> preferences[accessTokenKey] = token }
+    }
+}

--- a/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/repository/AuthRepository.kt
+++ b/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/repository/AuthRepository.kt
@@ -8,10 +8,8 @@ interface AuthRepository {
 
     fun signUpWithGoogle(googleToken: String, nickname: String): Flow<String>
 
-    suspend fun saveAccessToken(token: String)
-
-    suspend fun tryLoginAutomatically(): Boolean
-
     fun isDuplicatedNickname(nickname: String): Flow<Boolean>
+
+    suspend fun verifyToken(token: String): Boolean
 
 }

--- a/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/repository/UserTokenRepository.kt
+++ b/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/repository/UserTokenRepository.kt
@@ -1,0 +1,8 @@
+package com.ohdodok.catchytape.core.domain.repository
+
+interface UserTokenRepository {
+
+    suspend fun getAccessToken(): String
+
+    suspend fun saveAccessToken(token: String)
+}

--- a/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/usecase/AutomaticallyLoginUseCase.kt
+++ b/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/usecase/AutomaticallyLoginUseCase.kt
@@ -1,10 +1,19 @@
 package com.ohdodok.catchytape.core.domain.usecase
 
 import com.ohdodok.catchytape.core.domain.repository.AuthRepository
+import com.ohdodok.catchytape.core.domain.repository.UserTokenRepository
 import javax.inject.Inject
 
 class AutomaticallyLoginUseCase @Inject constructor(
-    private val authRepository: AuthRepository
+    private val authRepository: AuthRepository,
+    private val userTokenRepository: UserTokenRepository
 ) {
-    suspend operator fun invoke(): Boolean = authRepository.tryLoginAutomatically()
+    suspend operator fun invoke(): Boolean {
+        val accessToken = userTokenRepository.getAccessToken()
+        return if (accessToken.isNotEmpty()) {
+            authRepository.verifyToken(accessToken)
+        } else {
+            false
+        }
+    }
 }

--- a/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/usecase/LoginUseCase.kt
+++ b/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/usecase/LoginUseCase.kt
@@ -1,14 +1,18 @@
 package com.ohdodok.catchytape.core.domain.usecase
 
 import com.ohdodok.catchytape.core.domain.repository.AuthRepository
+import com.ohdodok.catchytape.core.domain.repository.UserTokenRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 class LoginUseCase @Inject constructor(
-    private val authRepository: AuthRepository
+    private val authRepository: AuthRepository,
+    private val userTokenRepository: UserTokenRepository
 ) {
 
     operator fun invoke(googleToken: String): Flow<Unit> =
-        authRepository.loginWithGoogle(googleToken).map { authRepository.saveAccessToken(it) }
+        authRepository.loginWithGoogle(googleToken).map {
+            userTokenRepository.saveAccessToken(it)
+        }
 }

--- a/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/usecase/SignUpUseCase.kt
+++ b/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/usecase/SignUpUseCase.kt
@@ -1,15 +1,19 @@
 package com.ohdodok.catchytape.core.domain.usecase
 
 import com.ohdodok.catchytape.core.domain.repository.AuthRepository
+import com.ohdodok.catchytape.core.domain.repository.UserTokenRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 class SignUpUseCase @Inject constructor(
-    private val authRepository: AuthRepository
+    private val authRepository: AuthRepository,
+    private val userTokenRepository: UserTokenRepository
 ) {
 
     operator fun invoke(googleToken: String, nickname: String): Flow<Unit> =
-        authRepository.signUpWithGoogle(googleToken, nickname).map { authRepository.saveAccessToken(it) }
+        authRepository.signUpWithGoogle(googleToken, nickname).map {
+            userTokenRepository.saveAccessToken(it)
+        }
 
 }


### PR DESCRIPTION
## Issue
- #179 

## Overview
- 현재 프로젝트는 데이터 소스 계층이 필요 없으므로, Token Local DataSource 를 Repository 레벨에서 관리하기 위해 UserTokenRepository 로 분리하였습니다.