### PR TITLE
플레이리스트 정보에 음악 개수, 썸네일 링크 추가

### DIFF
--- a/server/src/entity/music_playlist.entity.ts
+++ b/server/src/entity/music_playlist.entity.ts
@@ -81,4 +81,15 @@ export class Music_Playlist extends BaseEntity {
   static async getMusicCountByPlaylistId(playlist_id: number): Promise<number> {
     return this.count({ where: { playlist: { playlist_id } } });
   }
+
+  static async getThumbnailByPlaylistId(
+    playlist_id: number,
+  ): Promise<Music_Playlist> {
+    return this.findOne({
+      relations: { music: true },
+      select: { music: { cover: true } },
+      where: { playlist: { playlist_id } },
+      order: { music_playlist_id: 'DESC' },
+    });
+  }
 }

--- a/server/src/entity/music_playlist.entity.ts
+++ b/server/src/entity/music_playlist.entity.ts
@@ -77,4 +77,8 @@ export class Music_Playlist extends BaseEntity {
       take: 10,
     }).then((a: Music_Playlist[]) => a.map((b) => b.music));
   }
+
+  static async getMusicCountByPlaylistId(playlist_id: number): Promise<number> {
+    return this.count({ where: { playlist: { playlist_id } } });
+  }
 }

--- a/server/src/music/music.controller.ts
+++ b/server/src/music/music.controller.ts
@@ -65,7 +65,7 @@ export class MusicController {
   }
 
   @Get('info')
-  @HttpCode(HTTP_STATUS_CODE.SERVER_ERROR)
+  @HttpCode(HTTP_STATUS_CODE.SUCCESS)
   async getMusicInfo(@Query('music_id') music_id: string): Promise<Music> {
     return this.musicService.getMusicInfo(music_id);
   }

--- a/server/src/playlist/playlist.service.ts
+++ b/server/src/playlist/playlist.service.ts
@@ -166,7 +166,13 @@ export class PlaylistService {
 
   async getUserPlaylists(userId: string): Promise<Playlist[]> {
     try {
-      return Playlist.getPlaylistsByUserId(userId);
+      const playlists: Playlist[] = await Playlist.getPlaylistsByUserId(userId);
+      const promises = playlists.map(async (playlist) => {
+        playlist['music_count'] =
+          await Music_Playlist.getMusicCountByPlaylistId(playlist.playlist_id);
+      });
+      await Promise.all(promises);
+      return playlists;
     } catch {
       throw new CatchyException(
         'SERVER_ERROR',

--- a/server/src/playlist/playlist.service.ts
+++ b/server/src/playlist/playlist.service.ts
@@ -167,11 +167,18 @@ export class PlaylistService {
   async getUserPlaylists(userId: string): Promise<Playlist[]> {
     try {
       const playlists: Playlist[] = await Playlist.getPlaylistsByUserId(userId);
-      const promises = playlists.map(async (playlist) => {
+      const countPromises = playlists.map(async (playlist) => {
         playlist['music_count'] =
           await Music_Playlist.getMusicCountByPlaylistId(playlist.playlist_id);
       });
-      await Promise.all(promises);
+      const thumbnailPromises = playlists.map(async (playlist) => {
+        const target = await Music_Playlist.getThumbnailByPlaylistId(
+          playlist.playlist_id,
+        );
+        playlist['thumbnail'] = !target ? null : target.music.cover;
+      });
+      await Promise.all(countPromises);
+      await Promise.all(thumbnailPromises);
       return playlists;
     } catch {
       throw new CatchyException(


### PR DESCRIPTION
## Issue
- #215 

## Overview
- 플레이리스트 API 응답에 음악 개수, 썸네일 링크를 추가했습니다.
<br>

- playlist id 로 음악의 개수, 썸네일을 반환하는 함수들을 추가하여 처리했습니다.
- 특성상 쿼리문이 많이 발생하게 되어서 Promise.all 로 병렬 처리를 시켜서 시간을 단축시켰습니다.

## Screenshot
- 테스트 (11ms)
<img width="1392" alt="image" src="https://github.com/boostcampwm2023/and04-catchy-tape/assets/84065420/4e1da31d-ad7d-4c07-98fd-26bd9579e2e3">

## To Reviewers
참고자료 - [[JS] forEach 함수는 async 함수를 기다려주지 않는다](https://constructionsite.tistory.com/43)

쿼리문들을 병렬 처리시켜서 시간을 단축하기는 했지만, 쿼리문이 많이 발생하는 것이 사실이라 근본적으로 줄일 수 있다면 줄이는 것이 좋아 보입니다.