### PR TITLE
업로드 시 파일명 고정

### DIFF
--- a/server/src/music/music.service.ts
+++ b/server/src/music/music.service.ts
@@ -27,7 +27,7 @@ export class MusicService {
     this.objectStorage = ncloudConfigService.createObjectStorageOption();
   }
 
-  isValidGenre(genre: string): boolean {
+  private isValidGenre(genre: string): boolean {
     if (Object.values(Genres).includes(genre as Genres)) {
       return true;
     }
@@ -35,7 +35,7 @@ export class MusicService {
     return false;
   }
 
-  separateMusicName(musicPath: string): string {
+  private separateMusicName(musicPath: string): string {
     const parsedPath = new URL(musicPath);
     const pathNames = parsedPath.pathname.split('/');
     const musicName = pathNames[pathNames.length - 1];
@@ -43,11 +43,11 @@ export class MusicService {
     return musicName;
   }
 
-  getPath(option: string): string {
+  private getPath(option: string): string {
     return path.resolve(__dirname, `musics${option}`);
   }
 
-  setEncodingPaths(musicPath: string) {
+  private setEncodingPaths(musicPath: string) {
     const musicName: string = this.separateMusicName(musicPath);
 
     return {

--- a/server/src/music/music.service.ts
+++ b/server/src/music/music.service.ts
@@ -65,9 +65,6 @@ export class MusicService {
       const { outputMusicPath, entireMusicPath, outputPath, tempFilePath } =
         this.setEncodingPaths(musicPath);
 
-      console.log(tempFilePath);
-      console.log(musicPath);
-
       fs.mkdirSync(outputMusicPath, { recursive: true });
 
       const musicFileResponse = await axios.get(musicPath, {

--- a/server/src/upload/upload.service.ts
+++ b/server/src/upload/upload.service.ts
@@ -46,7 +46,7 @@ export class UploadService {
       const uploadResult = await this.objectStorage
         .upload({
           Bucket: 'catchy-tape-bucket2',
-          Key: `music/${musicId}/${file.originalname}`,
+          Key: `music/${musicId}/music.mp3`,
           Body: Readable.from(file.buffer),
           ContentType: contentTypeHandler.music,
           ACL: 'public-read',
@@ -85,10 +85,12 @@ export class UploadService {
         );
       }
 
+      const encodedFileName = encodeURIComponent(file.originalname);
+
       const keyPath =
         type === 'user'
-          ? `image/user/${id}/${file.originalname}`
-          : `image/cover/${id}/${file.originalname}`;
+          ? `image/user/${id}/image.png`
+          : `image/cover/${id}/image.png`;
 
       const uploadResult = await this.objectStorage
         .upload({
@@ -119,7 +121,7 @@ export class UploadService {
       const uploadResult = await this.objectStorage
         .upload({
           Bucket: 'catchy-tape-bucket2',
-          Key: `music/${musicId}/${fileName}`,
+          Key: `music/${musicId}/${fileName}}`,
           Body: fs.createReadStream(filePath),
           ACL: 'public-read',
         })


### PR DESCRIPTION
## Issue
- #124

## Overview
* 기존의 파일명은 한글로 들어가면 인코딩 문제로 골치를 앓아서, 경로가 이미 music과 user id로 구분되기 때문에 파일명은 고정시켰다.
* music.mp3, image.png로 고정
