### PR TITLE
MusicDTO의 title 필드를 영어와 한글만 입력받을 수 있도록 제한

### DIFF
--- a/server/src/dto/musicCreate.dto.ts
+++ b/server/src/dto/musicCreate.dto.ts
@@ -10,7 +10,7 @@ export class MusicCreateDto {
   @IsNotEmpty()
   @IsString()
   @MaxLength(50, { message: '글자 수가 50을 넘어갔습니다.' })
-  @Matches(/[\w]+|[가-힣]+/)
+  @Matches(/^[가-힣a-zA-Z ]*$/)
   title: string;
 
   @IsNotEmpty()


### PR DESCRIPTION
## Issue
- #124 

## Overview
* 정규표현식 수정
(** 다만 한글은 정확한 글자 형태를 갖춰야 함)

