### PR TITLE
이전, 다음 노래 이동 

### DIFF
--- a/android/app/src/main/java/com/ohdodok/catchytape/MainActivity.kt
+++ b/android/app/src/main/java/com/ohdodok/catchytape/MainActivity.kt
@@ -59,7 +59,7 @@ class MainActivity : AppCompatActivity() {
         setMedias()
         setupPlayer()
         setupPlayButton()
-        setupBeforeButton()
+        setupPreviousButton()
         setupNextButton()
     }
 
@@ -154,7 +154,7 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-    private fun setupBeforeButton() {
+    private fun setupPreviousButton() {
         binding.pcvController.setOnPreviousButtonClick {
             player.seekToPreviousMediaItem()
             player.play()

--- a/android/app/src/main/java/com/ohdodok/catchytape/MainActivity.kt
+++ b/android/app/src/main/java/com/ohdodok/catchytape/MainActivity.kt
@@ -169,13 +169,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun setMedias() {
-        val dummys = listOf(
-            "https://catchy-tape-bucket2.kr.object.ncloudstorage.com/music/379c98d8-df30-4df1-90a8-e9d45d80789a/music.m3u8",
-            "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8",
-            "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8"
-        ) // TODO : dummys 삭제 필요
-
-        val mediaItems = dummys.map { MediaItem.fromUri(it) }
+        val mediaItems = playViewModel.dummyUris.map { MediaItem.fromUri(it) }
         player.setMediaItems(mediaItems)
         player.play()
     }

--- a/android/app/src/main/java/com/ohdodok/catchytape/MainActivity.kt
+++ b/android/app/src/main/java/com/ohdodok/catchytape/MainActivity.kt
@@ -11,6 +11,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import androidx.media3.common.MediaItem
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.session.MediaController
 import androidx.media3.session.SessionToken
@@ -21,9 +22,9 @@ import androidx.navigation.ui.setupWithNavController
 import com.ohdodok.catchytape.databinding.ActivityMainBinding
 import com.ohdodok.catchytape.feature.player.PlayerListener
 import com.ohdodok.catchytape.feature.player.PlayerViewModel
-import com.ohdodok.catchytape.mediacontrol.PlaybackService
 import com.ohdodok.catchytape.feature.player.millisecondsPerSecond
 import com.ohdodok.catchytape.feature.player.navigateToPlayer
+import com.ohdodok.catchytape.mediacontrol.PlaybackService
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -55,8 +56,11 @@ class MainActivity : AppCompatActivity() {
         val networkStateObserver = NetworkStateObserver(connectivityManager, ::checkNetworkState)
         lifecycle.addObserver(networkStateObserver)
 
+        setMedias()
         setupPlayer()
         setupPlayButton()
+        setupBeforeButton()
+        setupNextButton()
     }
 
     override fun onStart() {
@@ -148,5 +152,31 @@ class MainActivity : AppCompatActivity() {
             if (playViewModel.uiState.value.isPlaying) player.pause()
             else player.play()
         }
+    }
+
+    private fun setupBeforeButton() {
+        binding.pcvController.setOnPreviousButtonClick {
+            player.seekToPreviousMediaItem()
+            player.play()
+        }
+    }
+
+    private fun setupNextButton() {
+        binding.pcvController.setOnNextButtonClick {
+            player.seekToNextMediaItem()
+            player.play()
+        }
+    }
+
+    private fun setMedias() {
+        val dummys = listOf(
+            "https://catchy-tape-bucket2.kr.object.ncloudstorage.com/music/379c98d8-df30-4df1-90a8-e9d45d80789a/music.m3u8",
+            "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8",
+            "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8"
+        ) // TODO : dummys 삭제 필요
+
+        val mediaItems = dummys.map { MediaItem.fromUri(it) }
+        player.setMediaItems(mediaItems)
+        player.play()
     }
 }

--- a/android/feature/player/src/main/java/com/ohdodok/catchytape/feature/player/PlayerControlView.kt
+++ b/android/feature/player/src/main/java/com/ohdodok/catchytape/feature/player/PlayerControlView.kt
@@ -52,9 +52,6 @@ class PlayerControlView(context: Context, attrs: AttributeSet) : ConstraintLayou
                 thumbnailUrl = getString(R.styleable.PlayerBarView_thumbnailUrl) ?: ""
                 title = getString(R.styleable.PlayerBarView_title) ?: ""
                 artist = getString(R.styleable.PlayerBarView_artist) ?: ""
-                isPlaying = getBoolean(R.styleable.PlayerBarView_isPlaying, false)
-                progress = getInt(R.styleable.PlayerBarView_progress, 0)
-                duration = getInt(R.styleable.PlayerBarView_duration, 0)
             } finally {
                 recycle()
             }

--- a/android/feature/player/src/main/java/com/ohdodok/catchytape/feature/player/PlayerControlView.kt
+++ b/android/feature/player/src/main/java/com/ohdodok/catchytape/feature/player/PlayerControlView.kt
@@ -74,4 +74,11 @@ class PlayerControlView(context: Context, attrs: AttributeSet) : ConstraintLayou
         else AppCompatResources.getDrawable(context, drawable.ic_play)
     }
 
+    fun setOnPreviousButtonClick(onPreviousButtonClick: () -> Unit) {
+        binding.ibPrevious.setOnClickListener { onPreviousButtonClick() }
+    }
+
+    fun setOnNextButtonClick(onNextButtonClick: () -> Unit) {
+        binding.ibNext.setOnClickListener { onNextButtonClick() }
+    }
 }

--- a/android/feature/player/src/main/java/com/ohdodok/catchytape/feature/player/PlayerFragment.kt
+++ b/android/feature/player/src/main/java/com/ohdodok/catchytape/feature/player/PlayerFragment.kt
@@ -29,7 +29,9 @@ class PlayerFragment : BaseFragment<FragmentPlayerBinding>(R.layout.fragment_pla
 
         setUpSeekBar()
         // todo : 실제 데이터로 변경
-        setMedia("https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8")
+        //setMedia("https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8")
+        setMedias()
+
         setupButtons()
         collectEvents()
     }
@@ -57,6 +59,19 @@ class PlayerFragment : BaseFragment<FragmentPlayerBinding>(R.layout.fragment_pla
         player.play()
     }
 
+    private fun setMedias() {
+        val dummys = listOf(
+            "https://catchy-tape-bucket2.kr.object.ncloudstorage.com/music/379c98d8-df30-4df1-90a8-e9d45d80789a/music.m3u8",
+            "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8",
+            "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8"
+        ) // TODO : dummys 삭제 필요
+
+        val mediaItems = dummys.map { MediaItem.fromUri(it) }
+        player.setMediaItems(mediaItems)
+        player.play()
+    }
+
+
     private fun setupButtons() {
         binding.btnPlay.setOnClickListener {
             if (viewModel.uiState.value.isPlaying) player.pause()
@@ -65,6 +80,16 @@ class PlayerFragment : BaseFragment<FragmentPlayerBinding>(R.layout.fragment_pla
 
         binding.ibDown.setOnClickListener {
             findNavController().popBackStack()
+        }
+
+        binding.btnNext.setOnClickListener {
+            player.seekToNextMediaItem()
+            player.play()
+        }
+
+        binding.btnPrevious.setOnClickListener {
+            player.seekToPreviousMediaItem()
+            player.play()
         }
     }
 

--- a/android/feature/player/src/main/java/com/ohdodok/catchytape/feature/player/PlayerFragment.kt
+++ b/android/feature/player/src/main/java/com/ohdodok/catchytape/feature/player/PlayerFragment.kt
@@ -60,13 +60,7 @@ class PlayerFragment : BaseFragment<FragmentPlayerBinding>(R.layout.fragment_pla
     }
 
     private fun setMedias() {
-        val dummys = listOf(
-            "https://catchy-tape-bucket2.kr.object.ncloudstorage.com/music/379c98d8-df30-4df1-90a8-e9d45d80789a/music.m3u8",
-            "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8",
-            "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8"
-        ) // TODO : dummys 삭제 필요
-
-        val mediaItems = dummys.map { MediaItem.fromUri(it) }
+        val mediaItems = viewModel.dummyUris.map { MediaItem.fromUri(it) }
         player.setMediaItems(mediaItems)
         player.play()
     }

--- a/android/feature/player/src/main/java/com/ohdodok/catchytape/feature/player/PlayerListener.kt
+++ b/android/feature/player/src/main/java/com/ohdodok/catchytape/feature/player/PlayerListener.kt
@@ -13,7 +13,7 @@ class PlayerListener(
                 listener.onPlayingChanged(player.isPlaying)
             }
 
-            events.contains(Player.EVENT_TIMELINE_CHANGED) -> {
+            events.containsAny(Player.EVENT_TIMELINE_CHANGED, Player.EVENT_MEDIA_ITEM_TRANSITION) -> {
                 val durationMs = player.duration.toInt()
                 listener.onMediaItemChanged(durationMs / millisecondsPerSecond)
             }

--- a/android/feature/player/src/main/java/com/ohdodok/catchytape/feature/player/PlayerViewModel.kt
+++ b/android/feature/player/src/main/java/com/ohdodok/catchytape/feature/player/PlayerViewModel.kt
@@ -28,6 +28,12 @@ class PlayerViewModel @Inject constructor(
 
 ) : ViewModel(), PlayerEventListener {
 
+    val dummyUris = listOf(
+        "https://catchy-tape-bucket2.kr.object.ncloudstorage.com/music/379c98d8-df30-4df1-90a8-e9d45d80789a/music.m3u8",
+        "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8",
+        "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8"
+    ) // TODO : dummys 삭제 필요
+
     private val _uiState = MutableStateFlow(PlayerState())
     val uiState: StateFlow<PlayerState> = _uiState.asStateFlow()
 

--- a/android/feature/player/src/main/res/layout/view_player_control.xml
+++ b/android/feature/player/src/main/res/layout/view_player_control.xml
@@ -28,7 +28,7 @@
             android:ellipsize="end"
             android:maxLines="1"
             app:layout_constraintBottom_toTopOf="@id/tv_artist"
-            app:layout_constraintEnd_toStartOf="@id/ib_play"
+            app:layout_constraintEnd_toStartOf="@id/ib_previous"
             app:layout_constraintStart_toEndOf="@id/iv_thumbnail"
             app:layout_constraintTop_toTopOf="@id/iv_thumbnail"
             app:layout_constraintVertical_chainStyle="packed"
@@ -48,13 +48,33 @@
             tools:text="데이먼스 이어" />
 
         <ImageButton
+            android:id="@+id/ib_previous"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:background="@android:color/transparent"
+            android:contentDescription="@string/previous_music"
+            android:src="@drawable/ic_previous"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/ib_play"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <ImageButton
             android:id="@+id/ib_play"
             android:layout_width="48dp"
             android:layout_height="48dp"
-            android:layout_marginEnd="6dp"
             android:background="@android:color/transparent"
-            android:contentDescription="@string/play"
             android:src="@drawable/ic_play"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/ib_next"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <ImageButton
+            android:id="@+id/ib_next"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:background="@android:color/transparent"
+            android:contentDescription="@string/next_music"
+            android:src="@drawable/ic_next"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent" />

--- a/android/feature/player/src/main/res/values/strings.xml
+++ b/android/feature/player/src/main/res/values/strings.xml
@@ -2,4 +2,6 @@
 <resources>
     <string name="minutes_and_seconds_format">%d:%02d</string>
     <string name="play">재생하기</string>
+    <string name="previous_music">이전 곡</string>
+    <string name="next_music">다음 곡</string>
 </resources>

--- a/android/feature/playlist/src/main/java/com/ohdodok/catchytape/feature/playlist/PlaylistsFragment.kt
+++ b/android/feature/playlist/src/main/java/com/ohdodok/catchytape/feature/playlist/PlaylistsFragment.kt
@@ -22,8 +22,9 @@ class PlaylistsFragment : BaseFragment<FragmentPlaylistsBinding>(R.layout.fragme
         viewModel.fetchPlaylists()
 
         observeEvents()
+        val newPlaylistDialog = NewPlaylistDialog()
         binding.fabNewPlaylist.setOnClickListener {
-            NewPlaylistDialog().show(childFragmentManager, NewPlaylistDialog.TAG)
+            newPlaylistDialog.show(childFragmentManager, NewPlaylistDialog.TAG)
         }
 
     }

--- a/android/feature/playlist/src/main/res/navigation/playlist_navigation.xml
+++ b/android/feature/playlist/src/main/res/navigation/playlist_navigation.xml
@@ -3,12 +3,12 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/playlist_nav_graph"
-    app:startDestination="@id/playlist_fragment">
+    app:startDestination="@id/playlists_fragment">
 
     <fragment
-        android:id="@+id/playlist_fragment"
+        android:id="@+id/playlists_fragment"
         android:name="com.ohdodok.catchytape.feature.playlist.PlaylistsFragment"
-        android:label="PlaylistsFragment"
+        android:label="playlists"
         tools:layout="@layout/fragment_playlists" />
 
 </navigation>


### PR DESCRIPTION
## Issue
- #12 

## Overview
- Bottom Player, PlayerFragment 2개에서 모두 이전, 다음 노래 이동 기능을 구현하였습니다.
- 현재 m3u8 파일은 dummys 데이터로 하드 코딩 하였고, 이후에 이 코드는 삭제 필요합니다.

- 현재 Issue 외에, 네이밍 개선과 불필요한 코드를 제거 하였습니다. (처음 3개의 커밋)

## Screenshot (optional)
<img width="271" alt="스크린샷 2023-12-04 14 18 51" src="https://github.com/boostcampwm2023/and04-catchy-tape/assets/59787852/b583e374-11a0-49c8-9c5e-05cdebb619f2">

