### PR TITLE
MediaSession 을 이용한 Media Control Player UI

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -28,7 +28,7 @@
             android:exported="true" />
 
         <service
-            android:name=".mediacontrol.PlaybackService"
+            android:name=".mediasession.PlaybackService"
             android:exported="true"
             android:foregroundServiceType="mediaPlayback">
             <intent-filter>

--- a/android/app/src/main/java/com/ohdodok/catchytape/MainActivity.kt
+++ b/android/app/src/main/java/com/ohdodok/catchytape/MainActivity.kt
@@ -24,7 +24,7 @@ import com.ohdodok.catchytape.feature.player.PlayerListener
 import com.ohdodok.catchytape.feature.player.PlayerViewModel
 import com.ohdodok.catchytape.feature.player.millisecondsPerSecond
 import com.ohdodok.catchytape.feature.player.navigateToPlayer
-import com.ohdodok.catchytape.mediacontrol.PlaybackService
+import com.ohdodok.catchytape.mediasession.PlaybackService
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch

--- a/android/app/src/main/java/com/ohdodok/catchytape/MainActivity.kt
+++ b/android/app/src/main/java/com/ohdodok/catchytape/MainActivity.kt
@@ -23,6 +23,8 @@ import com.ohdodok.catchytape.databinding.ActivityMainBinding
 import com.ohdodok.catchytape.feature.player.PlayerListener
 import com.ohdodok.catchytape.feature.player.PlayerViewModel
 import com.ohdodok.catchytape.feature.player.millisecondsPerSecond
+import com.ohdodok.catchytape.feature.player.moveNextMedia
+import com.ohdodok.catchytape.feature.player.movePreviousMedia
 import com.ohdodok.catchytape.feature.player.navigateToPlayer
 import com.ohdodok.catchytape.mediasession.PlaybackService
 import dagger.hilt.android.AndroidEntryPoint
@@ -148,15 +150,13 @@ class MainActivity : AppCompatActivity() {
 
     private fun setupPreviousButton() {
         binding.pcvController.setOnPreviousButtonClick {
-            player.seekToPreviousMediaItem()
-            player.play()
+            player.movePreviousMedia()
         }
     }
 
     private fun setupNextButton() {
         binding.pcvController.setOnNextButtonClick {
-            player.seekToNextMediaItem()
-            player.play()
+            player.moveNextMedia()
         }
     }
 

--- a/android/app/src/main/java/com/ohdodok/catchytape/mediasession/PlaybackService.kt
+++ b/android/app/src/main/java/com/ohdodok/catchytape/mediasession/PlaybackService.kt
@@ -1,4 +1,4 @@
-package com.ohdodok.catchytape.mediacontrol
+package com.ohdodok.catchytape.mediasession
 
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.session.MediaSession

--- a/android/feature/player/src/main/java/com/ohdodok/catchytape/feature/player/PlayerFragment.kt
+++ b/android/feature/player/src/main/java/com/ohdodok/catchytape/feature/player/PlayerFragment.kt
@@ -77,13 +77,11 @@ class PlayerFragment : BaseFragment<FragmentPlayerBinding>(R.layout.fragment_pla
         }
 
         binding.btnNext.setOnClickListener {
-            player.seekToNextMediaItem()
-            player.play()
+            player.moveNextMedia()
         }
 
         binding.btnPrevious.setOnClickListener {
-            player.seekToPreviousMediaItem()
-            player.play()
+            player.movePreviousMedia()
         }
     }
 

--- a/android/feature/player/src/main/java/com/ohdodok/catchytape/feature/player/PlayerUtil.kt
+++ b/android/feature/player/src/main/java/com/ohdodok/catchytape/feature/player/PlayerUtil.kt
@@ -6,7 +6,6 @@ import androidx.media3.common.MediaMetadata
 import androidx.media3.exoplayer.ExoPlayer
 import com.ohdodok.catchytape.core.domain.model.Music
 
-
 fun ExoPlayer.moveNextMedia() {
     seekToNextMediaItem()
     if (isPlaying) {
@@ -14,14 +13,12 @@ fun ExoPlayer.moveNextMedia() {
     }
 }
 
-
 fun ExoPlayer.movePreviousMedia() {
     seekToPreviousMediaItem()
     if (isPlaying) {
         play()
     }
 }
-
 
 fun getMediasWithMetaData(musics: List<Music>): List<MediaItem> {
     val mediaItemBuilder = MediaItem.Builder()

--- a/android/feature/player/src/main/java/com/ohdodok/catchytape/feature/player/PlayerUtil.kt
+++ b/android/feature/player/src/main/java/com/ohdodok/catchytape/feature/player/PlayerUtil.kt
@@ -8,21 +8,17 @@ import com.ohdodok.catchytape.core.domain.model.Music
 
 
 fun ExoPlayer.moveNextMedia() {
+    seekToNextMediaItem()
     if (isPlaying) {
-        seekToNextMediaItem()
         play()
-    } else {
-        seekToNextMediaItem()
     }
 }
 
 
 fun ExoPlayer.movePreviousMedia() {
+    seekToPreviousMediaItem()
     if (isPlaying) {
-        seekToPreviousMediaItem()
         play()
-    } else {
-        seekToPreviousMediaItem()
     }
 }
 

--- a/android/feature/player/src/main/java/com/ohdodok/catchytape/feature/player/PlayerUtil.kt
+++ b/android/feature/player/src/main/java/com/ohdodok/catchytape/feature/player/PlayerUtil.kt
@@ -1,0 +1,46 @@
+package com.ohdodok.catchytape.feature.player
+
+import androidx.core.net.toUri
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
+import androidx.media3.exoplayer.ExoPlayer
+import com.ohdodok.catchytape.core.domain.model.Music
+
+
+fun ExoPlayer.moveNextMedia() {
+    if (isPlaying) {
+        seekToNextMediaItem()
+        play()
+    } else {
+        seekToNextMediaItem()
+    }
+}
+
+
+fun ExoPlayer.movePreviousMedia() {
+    if (isPlaying) {
+        seekToPreviousMediaItem()
+        play()
+    } else {
+        seekToPreviousMediaItem()
+    }
+}
+
+
+fun getMediasWithMetaData(musics: List<Music>): List<MediaItem> {
+    val mediaItemBuilder = MediaItem.Builder()
+    val mediaMetadataBuilder = MediaMetadata.Builder()
+    return musics.map { music ->
+        mediaItemBuilder
+            .setMediaId(music.id)
+            .setUri("~~~~.m3u8") // TODO :Music domain에서 변수 추가 되면 반영해야 함
+            .setMediaMetadata(
+                mediaMetadataBuilder
+                    .setArtist(music.artist)
+                    .setTitle(music.title)
+                    .setArtworkUri(music.imageUrl.toUri())
+                    .build()
+            )
+            .build()
+    }
+}


### PR DESCRIPTION
## Issue
- #122 

## Overview
- Player에 대한 기능에서, MainActivity와 PlayerFragment 공통으로 사용하는 로직을 PlayerUtil.kt 파일에 확장함수로 작성하였습니다.

- MediaMetadata 을 설정해야, Media Control에 제대로 배경과, title 정보가 나타나게 됩니다. 
  - android api 33 이전 버전에도 MediaMetadata 설정을 해야 UI가 표시됩니다. 


## Screenshot
스크린샷은 Android api 33에서 찍었습니다. 

<img width="300" alt="스크린샷 2023-12-05 12 20 09" src="https://github.com/boostcampwm2023/and04-catchy-tape/assets/59787852/b2dd68a4-da39-4da0-9c6a-47431b8101da">

<img width="300" alt="스크린샷 2023-12-05 12 20 16" src="https://github.com/boostcampwm2023/and04-catchy-tape/assets/59787852/4771969c-01c7-45e9-b575-743a107497ba">
