### PR TITLE
노래 검색 및 더보기 기능

### DIFF
--- a/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/api/MusicApi.kt
+++ b/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/api/MusicApi.kt
@@ -6,6 +6,7 @@ import com.ohdodok.catchytape.core.data.model.MusicResponse
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.POST
+import retrofit2.http.Query
 
 interface MusicApi {
 
@@ -22,4 +23,10 @@ interface MusicApi {
 
     @GET("musics/my-uploads")
     suspend fun getMyUploads(): List<MusicResponse>
+
+
+    @GET("musics/search")
+    suspend fun getSearchedMusics(
+        @Query("keyword") keyword: String
+    ): List<MusicResponse>
 }

--- a/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/model/MusicResponse.kt
+++ b/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/model/MusicResponse.kt
@@ -12,7 +12,7 @@ data class MusicResponse (
     val cover: String,
     @SerialName("music_file")
     val musicFile : String,
-    val genre: String,
+    val genre: String = "",
     val user: NicknameResponse
 ) {
     fun toDomain(): Music {

--- a/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/model/MusicResponse.kt
+++ b/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/model/MusicResponse.kt
@@ -12,7 +12,7 @@ data class MusicResponse (
     val cover: String,
     @SerialName("music_file")
     val musicFile : String,
-    val genre: String = "",
+    val genre: String,
     val user: NicknameResponse
 ) {
     fun toDomain(): Music {

--- a/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/repository/MusicRepositoryImpl.kt
+++ b/android/core/data/src/main/java/com/ohdodok/catchytape/core/data/repository/MusicRepositoryImpl.kt
@@ -47,4 +47,9 @@ class MusicRepositoryImpl @Inject constructor(
         val myMusics = musicApi.getMyUploads()
         emit(myMusics.toDomains())
     }
+
+    override fun getSearchedMusics(keyword: String): Flow<List<Music>> = flow {
+        val searchedMusics = musicApi.getSearchedMusics(keyword)
+        emit(searchedMusics.toDomains())
+    }
 }

--- a/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/repository/MusicRepository.kt
+++ b/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/repository/MusicRepository.kt
@@ -13,4 +13,5 @@ interface MusicRepository {
 
     fun getMyMusics(): Flow<List<Music>>
 
+    fun getSearchedMusics(keyword: String): Flow<List<Music>>
 }

--- a/android/feature/search/src/main/java/com/ohdodok/catchytape/feature/search/SearchFragment.kt
+++ b/android/feature/search/src/main/java/com/ohdodok/catchytape/feature/search/SearchFragment.kt
@@ -3,12 +3,15 @@ package com.ohdodok.catchytape.feature.search
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.viewModels
+import com.ohdodok.catchytape.core.domain.model.Music
 import com.ohdodok.catchytape.core.ui.BaseFragment
 import com.ohdodok.catchytape.core.ui.MusicAdapter
 import com.ohdodok.catchytape.core.ui.Orientation
+import com.ohdodok.catchytape.core.ui.bindItems
 import com.ohdodok.catchytape.core.ui.toMessageId
 import com.ohdodok.catchytape.feature.search.databinding.FragmentSearchBinding
 import dagger.hilt.android.AndroidEntryPoint
+
 
 @AndroidEntryPoint
 class SearchFragment : BaseFragment<FragmentSearchBinding>(R.layout.fragment_search) {
@@ -20,6 +23,7 @@ class SearchFragment : BaseFragment<FragmentSearchBinding>(R.layout.fragment_sea
         binding.viewModel = viewModel
 
         observeEvents()
+        setupMoreButton()
         setupRecyclerView()
     }
 
@@ -36,6 +40,13 @@ class SearchFragment : BaseFragment<FragmentSearchBinding>(R.layout.fragment_sea
                     }
                 }
             }
+        }
+    }
+
+    private fun setupMoreButton() {
+        binding.btnMore.setOnClickListener {
+            binding.btnMore.visibility = View.INVISIBLE
+            binding.rvSearch.bindItems<Music, MusicAdapter.HorizontalViewHolder>(viewModel.searchedMusics.value.totalMusics)
         }
     }
 }

--- a/android/feature/search/src/main/java/com/ohdodok/catchytape/feature/search/SearchFragment.kt
+++ b/android/feature/search/src/main/java/com/ohdodok/catchytape/feature/search/SearchFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.viewModels
 import com.ohdodok.catchytape.core.ui.BaseFragment
+import com.ohdodok.catchytape.core.ui.toMessageId
 import com.ohdodok.catchytape.feature.search.databinding.FragmentSearchBinding
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -15,5 +16,19 @@ class SearchFragment : BaseFragment<FragmentSearchBinding>(R.layout.fragment_sea
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.viewModel = viewModel
+
+        observeEvents()
+    }
+
+    private fun observeEvents() {
+        repeatOnStarted {
+            viewModel.events.collect { event ->
+                when (event) {
+                    is SearchEvent.ShowMessage -> {
+                        showMessage(event.error.toMessageId())
+                    }
+                }
+            }
+        }
     }
 }

--- a/android/feature/search/src/main/java/com/ohdodok/catchytape/feature/search/SearchFragment.kt
+++ b/android/feature/search/src/main/java/com/ohdodok/catchytape/feature/search/SearchFragment.kt
@@ -4,6 +4,8 @@ import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.viewModels
 import com.ohdodok.catchytape.core.ui.BaseFragment
+import com.ohdodok.catchytape.core.ui.MusicAdapter
+import com.ohdodok.catchytape.core.ui.Orientation
 import com.ohdodok.catchytape.core.ui.toMessageId
 import com.ohdodok.catchytape.feature.search.databinding.FragmentSearchBinding
 import dagger.hilt.android.AndroidEntryPoint
@@ -18,6 +20,11 @@ class SearchFragment : BaseFragment<FragmentSearchBinding>(R.layout.fragment_sea
         binding.viewModel = viewModel
 
         observeEvents()
+        setupRecyclerView()
+    }
+
+    private fun setupRecyclerView() {
+        binding.rvSearch.adapter = MusicAdapter(Orientation.VERTICAL)
     }
 
     private fun observeEvents() {

--- a/android/feature/search/src/main/java/com/ohdodok/catchytape/feature/search/SearchFragment.kt
+++ b/android/feature/search/src/main/java/com/ohdodok/catchytape/feature/search/SearchFragment.kt
@@ -3,11 +3,9 @@ package com.ohdodok.catchytape.feature.search
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.viewModels
-import com.ohdodok.catchytape.core.domain.model.Music
 import com.ohdodok.catchytape.core.ui.BaseFragment
 import com.ohdodok.catchytape.core.ui.MusicAdapter
 import com.ohdodok.catchytape.core.ui.Orientation
-import com.ohdodok.catchytape.core.ui.bindItems
 import com.ohdodok.catchytape.core.ui.toMessageId
 import com.ohdodok.catchytape.feature.search.databinding.FragmentSearchBinding
 import dagger.hilt.android.AndroidEntryPoint
@@ -23,7 +21,6 @@ class SearchFragment : BaseFragment<FragmentSearchBinding>(R.layout.fragment_sea
         binding.viewModel = viewModel
 
         observeEvents()
-        setupMoreButton()
         setupRecyclerView()
     }
 
@@ -43,10 +40,4 @@ class SearchFragment : BaseFragment<FragmentSearchBinding>(R.layout.fragment_sea
         }
     }
 
-    private fun setupMoreButton() {
-        binding.btnMore.setOnClickListener {
-            binding.btnMore.visibility = View.INVISIBLE
-            binding.rvSearch.bindItems<Music, MusicAdapter.HorizontalViewHolder>(viewModel.searchedMusics.value.totalMusics)
-        }
-    }
 }

--- a/android/feature/search/src/main/java/com/ohdodok/catchytape/feature/search/SearchViewModel.kt
+++ b/android/feature/search/src/main/java/com/ohdodok/catchytape/feature/search/SearchViewModel.kt
@@ -1,26 +1,88 @@
 package com.ohdodok.catchytape.feature.search
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.ohdodok.catchytape.core.domain.model.CtErrorType
+import com.ohdodok.catchytape.core.domain.model.CtException
+import com.ohdodok.catchytape.core.domain.model.Music
+import com.ohdodok.catchytape.core.domain.repository.MusicRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.plus
 import javax.inject.Inject
 
 data class SearchUiState(
     val keyword: String = "",
 )
 
+data class SearchedMusics(
+    val maxThreeMusics: List<Music> = emptyList(),
+    val totalMusics: List<Music> = emptyList()
+)
+
 @HiltViewModel
 class SearchViewModel @Inject constructor(
-
+    private val musicRepository: MusicRepository
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(SearchUiState())
     val uiState: StateFlow<SearchUiState> = _uiState.asStateFlow()
 
+    private val _events = MutableSharedFlow<SearchEvent>()
+    val events: SharedFlow<SearchEvent> = _events.asSharedFlow()
+
+    private val _searchedMusics = MutableStateFlow(SearchedMusics())
+    val searchedMusics: StateFlow<SearchedMusics> = _searchedMusics.asStateFlow()
+
+
+    private val exceptionHandler = CoroutineExceptionHandler { _, throwable ->
+        val errorType =
+            if (throwable is CtException) throwable.ctError
+            else CtErrorType.UN_KNOWN
+
+        viewModelScope.launch { _events.emit(SearchEvent.ShowMessage(errorType)) }
+    }
+
+    private val viewModelScopeWithExceptionHandler = viewModelScope + exceptionHandler
+
+    init {
+        observeUiState()
+    }
+
     fun updateKeyword(newKeyword: String) {
         _uiState.update { it.copy(keyword = newKeyword) }
     }
+
+    private fun observeUiState() {
+        _uiState.debounce(300).onEach { uiState ->
+            if (uiState.keyword.isNotBlank()) {
+                fetchSearchedMusics(uiState.keyword)
+            }
+        }.launchIn(viewModelScopeWithExceptionHandler)
+    }
+
+    private fun fetchSearchedMusics(keyword: String) {
+        musicRepository.getSearchedMusics(keyword).onEach { musics ->
+            _searchedMusics.update {
+                it.copy(maxThreeMusics = musics.take(3), totalMusics = musics)
+            }
+        }.launchIn(viewModelScopeWithExceptionHandler)
+    }
+
+}
+
+
+sealed interface SearchEvent {
+    data class ShowMessage(val error: CtErrorType) : SearchEvent
 }

--- a/android/feature/search/src/main/java/com/ohdodok/catchytape/feature/search/SearchViewModel.kt
+++ b/android/feature/search/src/main/java/com/ohdodok/catchytape/feature/search/SearchViewModel.kt
@@ -52,14 +52,14 @@ class SearchViewModel @Inject constructor(
     private val viewModelScopeWithExceptionHandler = viewModelScope + exceptionHandler
 
     init {
-        observeUiState()
+        observeKeyword()
     }
 
     fun updateKeyword(newKeyword: String) {
         _keyword.update { newKeyword }
     }
 
-    private fun observeUiState() {
+    private fun observeKeyword() {
         _keyword.debounce(300).filter {
             it.isNotBlank()
         }.onEach {

--- a/android/feature/search/src/main/java/com/ohdodok/catchytape/feature/search/SearchViewModel.kt
+++ b/android/feature/search/src/main/java/com/ohdodok/catchytape/feature/search/SearchViewModel.kt
@@ -27,7 +27,6 @@ data class SearchUiState(
     val searchedMusics: List<Music> = emptyList()
 )
 
-
 @HiltViewModel
 class SearchViewModel @Inject constructor(
     private val musicRepository: MusicRepository

--- a/android/feature/search/src/main/java/com/ohdodok/catchytape/feature/search/SearchViewModel.kt
+++ b/android/feature/search/src/main/java/com/ohdodok/catchytape/feature/search/SearchViewModel.kt
@@ -60,11 +60,10 @@ class SearchViewModel @Inject constructor(
     }
 
     private fun observeKeyword() {
-        _keyword.debounce(300).filter {
-            it.isNotBlank()
-        }.onEach {
-            fetchSearchedMusics(it)
-        }.launchIn(viewModelScopeWithExceptionHandler)
+        _keyword.filter { it.isNotBlank() }
+            .debounce(300)
+            .onEach { fetchSearchedMusics(it) }
+            .launchIn(viewModelScopeWithExceptionHandler)
     }
 
     private fun fetchSearchedMusics(keyword: String) {

--- a/android/feature/search/src/main/res/layout/fragment_search.xml
+++ b/android/feature/search/src/main/res/layout/fragment_search.xml
@@ -50,7 +50,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_music"
-            app:list="@{viewModel.searchedMusics.maxThreeMusics}"
+            app:list="@{viewModel.uiState.searchedMusics}"
             tools:itemCount="3"
             tools:listitem="@layout/item_music_vertical" />
 

--- a/android/feature/search/src/main/res/layout/fragment_search.xml
+++ b/android/feature/search/src/main/res/layout/fragment_search.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <data>
 
@@ -14,6 +15,7 @@
         android:layout_height="match_parent">
 
         <EditText
+            android:id="@+id/et_search"
             android:layout_width="0dp"
             android:layout_height="44dp"
             android:layout_margin="@dimen/margin_horizontal"
@@ -25,6 +27,46 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tv_music"
+            style="@style/BodyLarge"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/margin_horizontal"
+            android:layout_marginTop="@dimen/extra_large"
+            android:text="@string/song"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/et_search" />
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn_more"
+            style="@style/BodySmall"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="@dimen/margin_horizontal"
+            android:background="@android:color/transparent"
+            android:minWidth="0dp"
+            android:minHeight="0dp"
+            android:text="@string/more"
+            app:layout_constraintBottom_toBottomOf="@id/tv_music"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@id/tv_music" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rv_search"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_marginTop="@dimen/small"
+            android:paddingHorizontal="@dimen/margin_horizontal"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/btn_more"
+            app:list="@{viewModel.uiState.searchedMusics}"
+            tools:itemCount="3"
+            tools:listitem="@layout/item_music_vertical" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/android/feature/search/src/main/res/layout/fragment_search.xml
+++ b/android/feature/search/src/main/res/layout/fragment_search.xml
@@ -64,7 +64,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/btn_more"
-            app:list="@{viewModel.uiState.searchedMusics}"
+            app:list="@{viewModel.searchedMusics.maxThreeMusics}"
             tools:itemCount="3"
             tools:listitem="@layout/item_music_vertical" />
 

--- a/android/feature/search/src/main/res/layout/fragment_search.xml
+++ b/android/feature/search/src/main/res/layout/fragment_search.xml
@@ -39,20 +39,6 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/et_search" />
 
-        <androidx.appcompat.widget.AppCompatButton
-            android:id="@+id/btn_more"
-            style="@style/BodySmall"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginEnd="@dimen/margin_horizontal"
-            android:background="@android:color/transparent"
-            android:minWidth="0dp"
-            android:minHeight="0dp"
-            android:text="@string/more"
-            app:layout_constraintBottom_toBottomOf="@id/tv_music"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="@id/tv_music" />
-
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/rv_search"
             android:layout_width="0dp"
@@ -63,7 +49,7 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/btn_more"
+            app:layout_constraintTop_toBottomOf="@id/tv_music"
             app:list="@{viewModel.searchedMusics.maxThreeMusics}"
             tools:itemCount="3"
             tools:listitem="@layout/item_music_vertical" />


### PR DESCRIPTION
## Issue
- #256

## Overview
- 스크린샷.gif 에서만 더보기 전에는 '2'개가 보이고, 더보기 클릭시 모두 표시하게 하였습니다 (코드 상에서는 3개를 표시해요)

- #239, PR merge 후에 노래 클릭시 player 화면으로 이동을 구현할 예정

## Screenshot (optional)

<img width="300" alt="1" src="https://github.com/boostcampwm2023/and04-catchy-tape/assets/59787852/e588019a-7bc1-49cc-8a31-00eb49231c4d">

<img width="300" alt="2" src="https://github.com/boostcampwm2023/and04-catchy-tape/assets/59787852/eda0d84e-e4af-44be-b6f3-13c424cc25fd">

<img src="https://github.com/boostcampwm2023/and04-catchy-tape/assets/59787852/2184f608-0ed1-46e4-9c8b-adadc8cf07ba" width="300" />
