### PR TITLE
바텀 내비게이션 스타일

### DIFF
--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -50,6 +50,8 @@
             android:id="@+id/bottom_nav"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:background="@color/surface_bright"
+            app:itemIconTint="@color/navigation_view_item_icon_tint"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"

--- a/android/core/ui/src/main/res/color/navigation_view_item_icon_tint.xml
+++ b/android/core/ui/src/main/res/color/navigation_view_item_icon_tint.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/on_surface"
+        android:state_pressed="true" android:state_checked="true"/>
+
+    <item android:color="@color/on_surface"/>
+</selector>

--- a/android/core/ui/src/main/res/values-night/themes.xml
+++ b/android/core/ui/src/main/res/values-night/themes.xml
@@ -6,6 +6,8 @@
         <item name="android:windowLightStatusBar">false</item>
         <item name="android:windowBackground">@color/surface</item>
         <item name="android:textColor">@color/on_surface</item>
+
+        <item name="colorSecondaryContainer">@color/primary_container</item>
     </style>
 
     <style name="Theme.CatchyTape" parent="Base.Theme.CatchyTape" />

--- a/android/core/ui/src/main/res/values/themes.xml
+++ b/android/core/ui/src/main/res/values/themes.xml
@@ -7,6 +7,8 @@
         <item name="android:windowLightStatusBar">true</item>
         <item name="android:windowBackground">@color/white</item>
         <item name="android:textColor">@color/on_surface</item>
+
+        <item name="colorSecondaryContainer">@color/primary_container</item>
     </style>
 
     <style name="Theme.CatchyTape" parent="Base.Theme.CatchyTape" />


### PR DESCRIPTION
## Issue
- #254 

## Overview
- 바텀 내비게이션 색깔 변경

## Screenshot
<img src="https://github.com/boostcampwm2023/and04-catchy-tape/assets/35232655/531cc900-9dea-4a28-a9e0-0eab7b6159ef" width="300" />
<img src="https://github.com/boostcampwm2023/and04-catchy-tape/assets/35232655/c4629614-f083-4f49-bdce-a00da726d15e" width="300" />

## To Reviewers
- 나중에 테마 정리가 필요할 것 같아
- 머티리얼 컴포넌트에서 secondary쪽 색깔까지 사용하는 것 같아서, 이번에 변경하면서 테마에 값 하나 지정해줬어.
- activeIndicator가 colorSecondaryContainer를 찾아서 적용하고 있어
