### PR TITLE
Recent_Played 테이블 생성 + API 수정

### DIFF
--- a/server/src/auth/auth.controller.spec.ts
+++ b/server/src/auth/auth.controller.spec.ts
@@ -5,11 +5,11 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { User } from 'src/entity/user.entity';
 import { Repository } from 'typeorm';
 import { JwtModule, JwtService } from '@nestjs/jwt';
-import { PlaylistService } from 'src/playlist/playlist.service';
 import { Playlist } from 'src/entity/playlist.entity';
 import { Music } from 'src/entity/music.entity';
 import { Music_Playlist } from 'src/entity/music_playlist.entity';
-import { Logger, LoggerService } from '@nestjs/common';
+import { Logger } from '@nestjs/common';
+import { PassportModule } from '@nestjs/passport';
 
 describe('AuthController', () => {
   let controller: AuthController;
@@ -19,7 +19,7 @@ describe('AuthController', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      imports: [JwtModule],
+      imports: [PassportModule.register({ defaultStrategy: 'jwt' }), JwtModule],
       controllers: [AuthController],
       providers: [
         Logger,
@@ -40,7 +40,6 @@ describe('AuthController', () => {
           provide: getRepositoryToken(Music_Playlist),
           useClass: Repository,
         },
-        PlaylistService,
       ],
     }).compile();
 

--- a/server/src/auth/auth.module.ts
+++ b/server/src/auth/auth.module.ts
@@ -7,9 +7,6 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from 'src/entity/user.entity';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
-import { Playlist } from 'src/entity/playlist.entity';
-import { Music } from 'src/entity/music.entity';
-import { Music_Playlist } from 'src/entity/music_playlist.entity';
 import { Logger } from 'winston';
 
 @Module({
@@ -23,7 +20,7 @@ import { Logger } from 'winston';
       }),
       inject: [ConfigService],
     }),
-    TypeOrmModule.forFeature([User, Playlist, Music, Music_Playlist]),
+    TypeOrmModule.forFeature([User]),
   ],
   providers: [JwtStrategy, AuthService, Logger],
   exports: [JwtStrategy, PassportModule],

--- a/server/src/auth/auth.module.ts
+++ b/server/src/auth/auth.module.ts
@@ -7,7 +7,6 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from 'src/entity/user.entity';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
-import { PlaylistService } from 'src/playlist/playlist.service';
 import { Playlist } from 'src/entity/playlist.entity';
 import { Music } from 'src/entity/music.entity';
 import { Music_Playlist } from 'src/entity/music_playlist.entity';
@@ -26,7 +25,7 @@ import { Logger } from 'winston';
     }),
     TypeOrmModule.forFeature([User, Playlist, Music, Music_Playlist]),
   ],
-  providers: [JwtStrategy, AuthService, PlaylistService, Logger],
+  providers: [JwtStrategy, AuthService, Logger],
   exports: [JwtStrategy, PassportModule],
   controllers: [AuthController],
 })

--- a/server/src/auth/auth.service.spec.ts
+++ b/server/src/auth/auth.service.spec.ts
@@ -8,6 +8,7 @@ import { PlaylistService } from 'src/playlist/playlist.service';
 import { Playlist } from 'src/entity/playlist.entity';
 import { Music } from 'src/entity/music.entity';
 import { Music_Playlist } from 'src/entity/music_playlist.entity';
+import { PassportModule } from '@nestjs/passport';
 
 describe('AuthService', () => {
   let service: AuthService;
@@ -17,7 +18,7 @@ describe('AuthService', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      imports: [JwtModule],
+      imports: [PassportModule.register({ defaultStrategy: 'jwt' }), JwtModule],
       providers: [
         AuthService,
         {

--- a/server/src/auth/auth.service.ts
+++ b/server/src/auth/auth.service.ts
@@ -3,11 +3,9 @@ import { JwtService } from '@nestjs/jwt';
 import { InjectRepository } from '@nestjs/typeorm';
 import { CatchyException } from 'src/config/catchyException';
 import { ERROR_CODE } from 'src/config/errorCode.enum';
-import { RECENT_PLAYLIST_NAME } from 'src/constants';
 import { UserCreateDto } from 'src/dto/userCreate.dto';
 import { User } from 'src/entity/user.entity';
 import { HTTP_STATUS_CODE } from 'src/httpStatusCode.enum';
-import { PlaylistService } from 'src/playlist/playlist.service';
 import { Repository } from 'typeorm';
 import { v4 as uuid } from 'uuid';
 
@@ -17,7 +15,6 @@ export class AuthService {
   constructor(
     @InjectRepository(User) private userRepository: Repository<User>,
     private jwtService: JwtService,
-    private readonly playlistService: PlaylistService,
   ) {}
 
   async login(email: string): Promise<{ accessToken: string }> {
@@ -62,9 +59,6 @@ export class AuthService {
       });
       await this.userRepository.save(newUser);
 
-      this.playlistService.createPlaylist(newUser.user_id, {
-        title: RECENT_PLAYLIST_NAME,
-      });
       return this.login(email);
     }
     this.logger.error(`auth.service - signup : WRONG_TOKEN`);

--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -14,7 +14,6 @@ export enum Genres {
   'etc' = 'etc',
 }
 
-export const RECENT_PLAYLIST_NAME = '최근 재생 목록';
 export const keyFlags = ['user', 'cover'];
 
 export const contentTypeHandler: Record<string, string> = {

--- a/server/src/entity/music.entity.ts
+++ b/server/src/entity/music.entity.ts
@@ -12,6 +12,7 @@ import {
 import { User } from './user.entity';
 import { Genres } from 'src/constants';
 import { Music_Playlist } from './music_playlist.entity';
+import { Recent_Played } from './recent_played.entity';
 
 @Entity({ name: 'music' })
 export class Music extends BaseEntity {
@@ -42,6 +43,9 @@ export class Music extends BaseEntity {
 
   @OneToMany(() => Music_Playlist, (music_playlist) => music_playlist.music)
   music_playlist: Music_Playlist[];
+
+  @OneToMany(() => Recent_Played, (recent_played) => recent_played.music)
+  recent_played: Recent_Played[];
 
   static async getMusicListByUserId(
     userId: string,

--- a/server/src/entity/music_playlist.entity.ts
+++ b/server/src/entity/music_playlist.entity.ts
@@ -24,7 +24,7 @@ export class Music_Playlist extends BaseEntity {
   playlist: Playlist;
 
   @Column()
-  updated_at: Date;
+  created_at: Date;
 
   static async getMusicListByPlaylistId(playlistId: number): Promise<Music[]> {
     return this.find({
@@ -46,7 +46,7 @@ export class Music_Playlist extends BaseEntity {
         music_playlist_id: false,
       },
       order: {
-        updated_at: 'DESC',
+        created_at: 'DESC',
       },
     }).then((a: Music_Playlist[]) => a.map((b) => b.music));
   }
@@ -77,7 +77,7 @@ export class Music_Playlist extends BaseEntity {
         },
       },
       order: {
-        updated_at: 'DESC',
+        created_at: 'DESC',
       },
       take: 10,
     }).then((a: Music_Playlist[]) => a.map((b) => b.music));
@@ -94,7 +94,7 @@ export class Music_Playlist extends BaseEntity {
       relations: { music: true },
       select: { music: { cover: true } },
       where: { playlist: { playlist_id } },
-      order: { updated_at: 'DESC' },
+      order: { created_at: 'DESC' },
     });
   }
 }

--- a/server/src/entity/music_playlist.entity.ts
+++ b/server/src/entity/music_playlist.entity.ts
@@ -8,7 +8,6 @@ import {
 } from 'typeorm';
 import { Music } from './music.entity';
 import { Playlist } from './playlist.entity';
-import { RECENT_PLAYLIST_NAME } from 'src/constants';
 
 @Entity({ name: 'music_playlist' })
 export class Music_Playlist extends BaseEntity {
@@ -48,38 +47,6 @@ export class Music_Playlist extends BaseEntity {
       order: {
         created_at: 'DESC',
       },
-    }).then((a: Music_Playlist[]) => a.map((b) => b.music));
-  }
-
-  static async getRecentPlayedMusicByUserId(userId: string): Promise<Music[]> {
-    return await this.find({
-      relations: {
-        music: true,
-      },
-      where: {
-        playlist: {
-          playlist_title: RECENT_PLAYLIST_NAME,
-        },
-        music: {
-          user: {
-            user_id: userId,
-          },
-        },
-      },
-      select: {
-        music_playlist_id: false,
-        music: {
-          music_id: true,
-          title: true,
-          music_file: true,
-          cover: true,
-          genre: true,
-        },
-      },
-      order: {
-        created_at: 'DESC',
-      },
-      take: 10,
     }).then((a: Music_Playlist[]) => a.map((b) => b.music));
   }
 

--- a/server/src/entity/recent_played.entity.ts
+++ b/server/src/entity/recent_played.entity.ts
@@ -31,7 +31,7 @@ export class Recent_Played extends BaseEntity {
   ): Promise<Music[]> {
     return await this.find({
       relations: {
-        music: true,
+        music: { user: true },
         user: true,
       },
       where: {
@@ -47,6 +47,7 @@ export class Recent_Played extends BaseEntity {
           music_file: true,
           cover: true,
           genre: true,
+          user: { user_id: true, nickname: true },
         },
       },
       order: {

--- a/server/src/entity/recent_played.entity.ts
+++ b/server/src/entity/recent_played.entity.ts
@@ -1,0 +1,27 @@
+import {
+  BaseEntity,
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { Music } from './music.entity';
+import { User } from './user.entity';
+
+@Entity({ name: 'recent_played' })
+export class Recent_Played extends BaseEntity {
+  @PrimaryGeneratedColumn()
+  recent_played_id: number;
+
+  @ManyToOne(() => Music, (music) => music.recent_played)
+  @JoinColumn({ name: 'music_id' })
+  music: Music;
+
+  @ManyToOne(() => User, (user) => user.recent_played)
+  @JoinColumn({ name: 'user_id' })
+  user: User;
+
+  @Column()
+  played_at: Date;
+}

--- a/server/src/entity/recent_played.entity.ts
+++ b/server/src/entity/recent_played.entity.ts
@@ -24,4 +24,37 @@ export class Recent_Played extends BaseEntity {
 
   @Column()
   played_at: Date;
+
+  static async getRecentPlayedMusicByUserId(
+    user_id: string,
+    count: number,
+  ): Promise<Music[]> {
+    return await this.find({
+      relations: {
+        music: true,
+        user: true,
+      },
+      where: {
+        user: {
+          user_id,
+        },
+      },
+      select: {
+        recent_played_id: false,
+        music: {
+          music_id: true,
+          title: true,
+          music_file: true,
+          cover: true,
+          genre: true,
+        },
+      },
+      order: {
+        played_at: 'DESC',
+      },
+      take: count,
+    }).then((recent_played: Recent_Played[]) =>
+      recent_played.map((recent) => recent.music),
+    );
+  }
 }

--- a/server/src/entity/user.entity.ts
+++ b/server/src/entity/user.entity.ts
@@ -9,6 +9,7 @@ import {
 } from 'typeorm';
 import { Playlist } from './playlist.entity';
 import { Music } from './music.entity';
+import { Recent_Played } from './recent_played.entity';
 
 @Entity({ name: 'user' })
 export class User extends BaseEntity {
@@ -32,6 +33,9 @@ export class User extends BaseEntity {
 
   @OneToMany(() => Playlist, (playlist) => playlist.user)
   playlists: Playlist[];
+
+  @OneToMany(() => Recent_Played, (recent_played) => recent_played.user)
+  recent_played: Recent_Played[];
 
   static async getCertainUserByNickname(keyword: string): Promise<User[]> {
     return this.find({

--- a/server/src/music/music.controller.spec.ts
+++ b/server/src/music/music.controller.spec.ts
@@ -8,16 +8,11 @@ import { ConfigService } from '@nestjs/config';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Music } from 'src/entity/music.entity';
-import { realMusicCreateInfo, user } from 'test/constants/music.mockData';
+import { user } from 'test/constants/music.mockData';
 import { MusicController } from './music.controller';
-import * as request from 'supertest';
-import { HTTP_STATUS_CODE } from 'src/httpStatusCode.enum';
 import { User } from 'src/entity/user.entity';
 import { AuthService } from 'src/auth/auth.service';
 import { JwtService } from '@nestjs/jwt';
-import { PlaylistService } from 'src/playlist/playlist.service';
-import { Playlist } from 'src/entity/playlist.entity';
-import { Music_Playlist } from 'src/entity/music_playlist.entity';
 import { AuthGuard } from '@nestjs/passport';
 import { GreenEyeService } from 'src/config/greenEye.service';
 
@@ -40,7 +35,6 @@ describe('UploadController', () => {
         ConfigService,
         GreenEyeService,
         AuthService,
-        PlaylistService,
         JwtService,
         {
           provide: getRepositoryToken(Music),
@@ -48,14 +42,6 @@ describe('UploadController', () => {
         },
         {
           provide: getRepositoryToken(User),
-          useClass: Repository,
-        },
-        {
-          provide: getRepositoryToken(Playlist),
-          useClass: Repository,
-        },
-        {
-          provide: getRepositoryToken(Music_Playlist),
           useClass: Repository,
         },
       ],

--- a/server/src/music/music.service.spec.ts
+++ b/server/src/music/music.service.spec.ts
@@ -15,6 +15,7 @@ import {
   newMusicData,
 } from 'test/constants/music.mockData';
 import { GreenEyeService } from 'src/config/greenEye.service';
+import { Recent_Played } from 'src/entity/recent_played.entity';
 
 describe('UploadController', () => {
   let app: INestApplication;
@@ -36,6 +37,10 @@ describe('UploadController', () => {
         GreenEyeService,
         {
           provide: getRepositoryToken(Music),
+          useClass: Repository,
+        },
+        {
+          provide: getRepositoryToken(Recent_Played),
           useClass: Repository,
         },
       ],

--- a/server/src/playlist/playlist.controller.ts
+++ b/server/src/playlist/playlist.controller.ts
@@ -88,20 +88,4 @@ export class PlaylistController {
     const userId: string = req.user.user_id;
     return await this.playlistService.getPlaylistMusics(userId, playlistId);
   }
-
-  @Put('recent-played')
-  @UseGuards(AuthGuard())
-  @HttpCode(HTTP_STATUS_CODE.SUCCESS)
-  async updateRecentPlayMusic(
-    @Req() req,
-    @Body('musicId') music_id: string,
-  ): Promise<{ recent_played_id: number }> {
-    this.logger.log(
-      `PUT /playlists/recent-played - nickname=${req.user.nickname}, music_id=${music_id}`,
-    );
-    const user_id: string = req.user.user_id;
-    const recent_played_id: number =
-      await this.playlistService.updateRecentMusic(music_id, user_id);
-    return { recent_played_id };
-  }
 }

--- a/server/src/playlist/playlist.controller.ts
+++ b/server/src/playlist/playlist.controller.ts
@@ -5,8 +5,8 @@ import {
   HttpCode,
   Logger,
   Param,
-  Patch,
   Post,
+  Put,
   Req,
   UseGuards,
   UsePipes,
@@ -22,9 +22,7 @@ import { Music } from 'src/entity/music.entity';
 @Controller('playlists')
 export class PlaylistController {
   private readonly logger = new Logger('Playlist');
-  constructor(
-    private playlistService: PlaylistService,
-  ) {}
+  constructor(private playlistService: PlaylistService) {}
 
   @Post()
   @UseGuards(AuthGuard())
@@ -91,34 +89,19 @@ export class PlaylistController {
     return await this.playlistService.getPlaylistMusics(userId, playlistId);
   }
 
-  @Patch('recent-played')
+  @Put('recent-played')
   @UseGuards(AuthGuard())
   @HttpCode(HTTP_STATUS_CODE.SUCCESS)
   async updateRecentPlayMusic(
     @Req() req,
     @Body('musicId') music_id: string,
-  ): Promise<{ music_playlist_id: number }> {
+  ): Promise<{ recent_played_id: number }> {
     this.logger.log(
-      `PATCH /playlists/recent-played - nickname=${req.user.nickname}, music_id=${music_id}`,
+      `PUT /playlists/recent-played - nickname=${req.user.nickname}, music_id=${music_id}`,
     );
     const user_id: string = req.user.user_id;
-    const recentPlaylist: Playlist =
-      await this.playlistService.getRecentPlaylist(user_id);
-    const recentPlaylistId: number = recentPlaylist.playlist_id;
-    if (await this.playlistService.isAlreadyAdded(recentPlaylistId, music_id)) {
-      return {
-        music_playlist_id: await this.playlistService.updateRecentMusic(
-          music_id,
-          recentPlaylistId,
-        ),
-      };
-    }
-    return {
-      music_playlist_id: await this.playlistService.addMusicToPlaylist(
-        user_id,
-        recentPlaylistId,
-        music_id,
-      ),
-    };
+    const recent_played_id: number =
+      await this.playlistService.updateRecentMusic(music_id, user_id);
+    return { recent_played_id };
   }
 }

--- a/server/src/playlist/playlist.module.ts
+++ b/server/src/playlist/playlist.module.ts
@@ -7,11 +7,10 @@ import { AuthModule } from 'src/auth/auth.module';
 import { Music_Playlist } from 'src/entity/music_playlist.entity';
 import { Music } from 'src/entity/music.entity';
 import { Logger } from 'winston';
-import { Recent_Played } from 'src/entity/recent_played.entity';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Playlist, Music_Playlist, Music, Recent_Played]),
+    TypeOrmModule.forFeature([Playlist, Music_Playlist, Music]),
     AuthModule,
   ],
   controllers: [PlaylistController],

--- a/server/src/playlist/playlist.module.ts
+++ b/server/src/playlist/playlist.module.ts
@@ -7,10 +7,11 @@ import { AuthModule } from 'src/auth/auth.module';
 import { Music_Playlist } from 'src/entity/music_playlist.entity';
 import { Music } from 'src/entity/music.entity';
 import { Logger } from 'winston';
+import { Recent_Played } from 'src/entity/recent_played.entity';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Playlist, Music_Playlist, Music]),
+    TypeOrmModule.forFeature([Playlist, Music_Playlist, Music, Recent_Played]),
     AuthModule,
   ],
   controllers: [PlaylistController],

--- a/server/src/playlist/playlist.service.ts
+++ b/server/src/playlist/playlist.service.ts
@@ -94,7 +94,7 @@ export class PlaylistService {
         this.music_playlistRepository.create({
           music: { music_id: musicId },
           playlist: { playlist_id: playlistId },
-          updated_at: new Date(),
+          created_at: new Date(),
         });
 
       const result: Music_Playlist =
@@ -281,7 +281,7 @@ export class PlaylistService {
           where: { music: { music_id }, playlist: { playlist_id } },
         });
 
-      music_playlist.updated_at = new Date();
+      music_playlist.created_at = new Date();
       const savedData: Music_Playlist =
         await this.music_playlistRepository.save(music_playlist);
       return savedData.music_playlist_id;

--- a/server/src/playlist/playlist.service.ts
+++ b/server/src/playlist/playlist.service.ts
@@ -6,7 +6,6 @@ import { PlaylistCreateDto } from 'src/dto/playlistCreate.dto';
 import { Music } from 'src/entity/music.entity';
 import { Music_Playlist } from 'src/entity/music_playlist.entity';
 import { Playlist } from 'src/entity/playlist.entity';
-import { Recent_Played } from 'src/entity/recent_played.entity';
 import { HTTP_STATUS_CODE } from 'src/httpStatusCode.enum';
 import { Repository } from 'typeorm';
 
@@ -20,8 +19,6 @@ export class PlaylistService {
     private music_playlistRepository: Repository<Music_Playlist>,
     @InjectRepository(Music)
     private MusicRepository: Repository<Music>,
-    @InjectRepository(Recent_Played)
-    private recentPlayedRepository: Repository<Recent_Played>,
   ) {}
 
   async createPlaylist(
@@ -236,60 +233,6 @@ export class PlaylistService {
         'SERVER_ERROR',
         HTTP_STATUS_CODE.SERVER_ERROR,
         ERROR_CODE.SERVICE_ERROR,
-      );
-    }
-  }
-
-  async isExistMusicInRecentPlaylist(
-    music_id: string,
-    user_id: string,
-  ): Promise<boolean> {
-    try {
-      const musicCount: number = await this.recentPlayedRepository.count({
-        where: { music: { music_id }, user: { user_id } },
-      });
-      return musicCount != 0;
-    } catch {
-      this.logger.error(
-        `playlist.service - isExistMusicInRecentPlaylist : QUERY_ERROR`,
-      );
-      throw new CatchyException(
-        'QUERY_ERROR',
-        HTTP_STATUS_CODE.SERVER_ERROR,
-        ERROR_CODE.QUERY_ERROR,
-      );
-    }
-  }
-
-  async updateRecentMusic(music_id: string, user_id: string): Promise<number> {
-    try {
-      if (!(await this.isExistMusicInRecentPlaylist(music_id, user_id))) {
-        const newRow: Recent_Played = this.recentPlayedRepository.create({
-          music: { music_id },
-          user: { user_id },
-          played_at: new Date(),
-        });
-        const addedRow: Recent_Played =
-          await this.recentPlayedRepository.save(newRow);
-        return addedRow.recent_played_id;
-      }
-
-      const targetRow: Recent_Played =
-        await this.recentPlayedRepository.findOne({
-          where: { music: { music_id }, user: { user_id } },
-        });
-      targetRow.played_at = new Date();
-      const updatedRow: Recent_Played =
-        await this.recentPlayedRepository.save(targetRow);
-      return updatedRow.recent_played_id;
-    } catch (err) {
-      if (err instanceof CatchyException) throw err;
-
-      this.logger.error(`playlist.service - updateRecentMusic : SERVICE_ERROR`);
-      throw new CatchyException(
-        'SERVICE_ERROR',
-        HTTP_STATUS_CODE.SERVER_ERROR,
-        ERROR_CODE.QUERY_ERROR,
       );
     }
   }

--- a/server/src/playlist/playlist.service.ts
+++ b/server/src/playlist/playlist.service.ts
@@ -240,21 +240,6 @@ export class PlaylistService {
     }
   }
 
-  async getRecentMusicsByUserId(userId: string) {
-    try {
-      return Music_Playlist.getRecentPlayedMusicByUserId(userId);
-    } catch {
-      this.logger.error(
-        `playlist.service - getRecentMusicsByUserId : SERVER_ERROR`,
-      );
-      throw new CatchyException(
-        'SERVER ERROR',
-        HTTP_STATUS_CODE.SERVER_ERROR,
-        ERROR_CODE.SERVER_ERROR,
-      );
-    }
-  }
-
   async isExistMusicInRecentPlaylist(
     music_id: string,
     user_id: string,

--- a/server/src/playlist/playlist.service.ts
+++ b/server/src/playlist/playlist.service.ts
@@ -7,6 +7,7 @@ import { PlaylistCreateDto } from 'src/dto/playlistCreate.dto';
 import { Music } from 'src/entity/music.entity';
 import { Music_Playlist } from 'src/entity/music_playlist.entity';
 import { Playlist } from 'src/entity/playlist.entity';
+import { Recent_Played } from 'src/entity/recent_played.entity';
 import { HTTP_STATUS_CODE } from 'src/httpStatusCode.enum';
 import { Repository } from 'typeorm';
 
@@ -20,6 +21,8 @@ export class PlaylistService {
     private music_playlistRepository: Repository<Music_Playlist>,
     @InjectRepository(Music)
     private MusicRepository: Repository<Music>,
+    @InjectRepository(Recent_Played)
+    private recentPlaylistRepository: Repository<Recent_Played>,
   ) {}
 
   async createPlaylist(
@@ -263,6 +266,21 @@ export class PlaylistService {
       });
     } catch {
       this.logger.error(`playlist.service - getRecentPlaylist : QUERY_ERROR`);
+      throw new CatchyException(
+        'QUERY_ERROR',
+        HTTP_STATUS_CODE.SERVER_ERROR,
+        ERROR_CODE.QUERY_ERROR,
+      );
+    }
+  }
+
+  async isExistMusicInRecentPlaylist(music_id: string, user_id: string) {
+    try {
+      const musicCount: number = await this.recentPlaylistRepository.count({
+        where: { music: { music_id }, user: { user_id } },
+      });
+      return musicCount != 0;
+    } catch {
       throw new CatchyException(
         'QUERY_ERROR',
         HTTP_STATUS_CODE.SERVER_ERROR,

--- a/server/src/playlist/playlist.service.ts
+++ b/server/src/playlist/playlist.service.ts
@@ -255,24 +255,6 @@ export class PlaylistService {
     }
   }
 
-  // async getRecentPlaylist(user_id: string): Promise<Playlist> {
-  //   try {
-  //     return await this.playlistRepository.findOne({
-  //       where: {
-  //         user: { user_id },
-  //         playlist_title: RECENT_PLAYLIST_NAME,
-  //       },
-  //     });
-  //   } catch {
-  //     this.logger.error(`playlist.service - getRecentPlaylist : QUERY_ERROR`);
-  //     throw new CatchyException(
-  //       'QUERY_ERROR',
-  //       HTTP_STATUS_CODE.SERVER_ERROR,
-  //       ERROR_CODE.QUERY_ERROR,
-  //     );
-  //   }
-  // }
-
   async isExistMusicInRecentPlaylist(
     music_id: string,
     user_id: string,
@@ -326,28 +308,4 @@ export class PlaylistService {
       );
     }
   }
-
-  // async updateRecentMusic(
-  //   music_id: string,
-  //   playlist_id: number,
-  // ): Promise<number> {
-  //   try {
-  //     const music_playlist: Music_Playlist =
-  //       await this.music_playlistRepository.findOne({
-  //         where: { music: { music_id }, playlist: { playlist_id } },
-  //       });
-
-  //     music_playlist.created_at = new Date();
-  //     const savedData: Music_Playlist =
-  //       await this.music_playlistRepository.save(music_playlist);
-  //     return savedData.music_playlist_id;
-  //   } catch {
-  //     this.logger.error(`playlist.service - updateRecentMusic : SERVICE_ERROR`);
-  //     throw new CatchyException(
-  //       'SERVICE_ERROR',
-  //       HTTP_STATUS_CODE.SERVER_ERROR,
-  //       ERROR_CODE.SERVICE_ERROR,
-  //     );
-  //   }
-  // }
 }

--- a/server/src/user/user.controller.spec.ts
+++ b/server/src/user/user.controller.spec.ts
@@ -4,15 +4,11 @@ import { UserService } from './user.service';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { User } from 'src/entity/user.entity';
 import { Repository } from 'typeorm';
-import { PlaylistService } from 'src/playlist/playlist.service';
-import { Music } from 'src/entity/music.entity';
-import { Music_Playlist } from 'src/entity/music_playlist.entity';
-import { Playlist } from 'src/entity/playlist.entity';
+import { Recent_Played } from 'src/entity/recent_played.entity';
 
 describe('UserController', () => {
   let controller: UserController;
   let userService: UserService;
-  let playlistService: PlaylistService;
   let userRepository: Repository<User>;
 
   beforeEach(async () => {
@@ -20,21 +16,12 @@ describe('UserController', () => {
       controllers: [UserController],
       providers: [
         UserService,
-        PlaylistService,
         {
           provide: getRepositoryToken(User),
           useClass: Repository,
         },
         {
-          provide: getRepositoryToken(Playlist),
-          useClass: Repository,
-        },
-        {
-          provide: getRepositoryToken(Music),
-          useClass: Repository,
-        },
-        {
-          provide: getRepositoryToken(Music_Playlist),
+          provide: getRepositoryToken(Recent_Played),
           useClass: Repository,
         },
       ],
@@ -42,7 +29,6 @@ describe('UserController', () => {
 
     controller = module.get<UserController>(UserController);
     userService = module.get<UserService>(UserService);
-    playlistService = module.get<PlaylistService>(PlaylistService);
     userRepository = module.get(getRepositoryToken(User));
   });
 

--- a/server/src/user/user.controller.ts
+++ b/server/src/user/user.controller.ts
@@ -21,9 +21,7 @@ import { User } from 'src/entity/user.entity';
 @Controller('users')
 export class UserController {
   private readonly logger = new Logger('User');
-  constructor(
-    private userService: UserService,
-  ) {}
+  constructor(private userService: UserService) {}
 
   @Get('duplicate/:name')
   @HttpCode(HTTP_STATUS_CODE.NOT_DUPLICATED_NICKNAME)
@@ -45,11 +43,16 @@ export class UserController {
   @Get('recent-played')
   @UseGuards(AuthGuard())
   @HttpCode(HTTP_STATUS_CODE.SUCCESS)
-  async getUserRecentPlayedMusics(@Req() req): Promise<Music[]> {
+  async getUserRecentPlayedMusics(
+    @Req() req,
+    @Query('count') count: number,
+  ): Promise<Music[]> {
     this.logger.log(`GET /users/recent-played - nickname=${req.user.nickname}`);
     const userId = req.user.userId;
-    const userMusicData =
-      await this.userService.getRecentPlayedMusicByUserId(userId);
+    const userMusicData = await this.userService.getRecentPlayedMusicByUserId(
+      userId,
+      count,
+    );
 
     return userMusicData;
   }

--- a/server/src/user/user.controller.ts
+++ b/server/src/user/user.controller.ts
@@ -101,7 +101,7 @@ export class UserController {
     @Body('musicId') music_id: string,
   ): Promise<{ recent_played_id: number }> {
     this.logger.log(
-      `PUT /playlists/recent-played - nickname=${req.user.nickname}, music_id=${music_id}`,
+      `PUT /user/recent-played - nickname=${req.user.nickname}, music_id=${music_id}`,
     );
     const user_id: string = req.user.user_id;
     const recent_played_id: number = await this.userService.updateRecentMusic(
@@ -109,5 +109,20 @@ export class UserController {
       user_id,
     );
     return { recent_played_id };
+  }
+
+  @Get('recent-info')
+  @UseGuards(AuthGuard())
+  @HttpCode(HTTP_STATUS_CODE.SUCCESS)
+  async getRecentPlaylistInfo(
+    @Req() req,
+  ): Promise<{ music_count: number; thumbnail: string }> {
+    const user_id: string = req.user.user_id;
+    this.logger.log(`GET /user/recent-info - nickname=${req.user.nickname}`);
+    const music_count: number =
+      await this.userService.getRecentPlaylistMusicCount(user_id);
+    const thumbnail: string =
+      await this.userService.getRecentPlaylistThumbnail(user_id);
+    return { music_count, thumbnail };
   }
 }

--- a/server/src/user/user.controller.ts
+++ b/server/src/user/user.controller.ts
@@ -9,6 +9,7 @@ import {
   Body,
   Query,
   Logger,
+  Put,
 } from '@nestjs/common';
 import { UserService } from './user.service';
 import { HTTP_STATUS_CODE } from 'src/httpStatusCode.enum';
@@ -90,5 +91,23 @@ export class UserController {
   ): Promise<User[]> {
     this.logger.log(`GET /users/search - keyword=${keyword}`);
     return this.userService.getCertainKeywordNicknameUser(keyword);
+  }
+
+  @Put('recent-played')
+  @UseGuards(AuthGuard())
+  @HttpCode(HTTP_STATUS_CODE.SUCCESS)
+  async updateRecentPlayMusic(
+    @Req() req,
+    @Body('musicId') music_id: string,
+  ): Promise<{ recent_played_id: number }> {
+    this.logger.log(
+      `PUT /playlists/recent-played - nickname=${req.user.nickname}, music_id=${music_id}`,
+    );
+    const user_id: string = req.user.user_id;
+    const recent_played_id: number = await this.userService.updateRecentMusic(
+      music_id,
+      user_id,
+    );
+    return { recent_played_id };
   }
 }

--- a/server/src/user/user.module.ts
+++ b/server/src/user/user.module.ts
@@ -5,9 +5,10 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from 'src/entity/user.entity';
 import { AuthModule } from 'src/auth/auth.module';
 import { Logger } from 'winston';
+import { Recent_Played } from 'src/entity/recent_played.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User]), AuthModule],
+  imports: [TypeOrmModule.forFeature([User, Recent_Played]), AuthModule],
   controllers: [UserController],
   providers: [UserService, Logger],
 })

--- a/server/src/user/user.module.ts
+++ b/server/src/user/user.module.ts
@@ -9,10 +9,17 @@ import { Playlist } from 'src/entity/playlist.entity';
 import { Music_Playlist } from 'src/entity/music_playlist.entity';
 import { Music } from 'src/entity/music.entity';
 import { Logger } from 'winston';
+import { Recent_Played } from 'src/entity/recent_played.entity';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([User, Playlist, Music_Playlist, Music]),
+    TypeOrmModule.forFeature([
+      User,
+      Playlist,
+      Music_Playlist,
+      Music,
+      Recent_Played,
+    ]),
     AuthModule,
   ],
   controllers: [UserController],

--- a/server/src/user/user.module.ts
+++ b/server/src/user/user.module.ts
@@ -4,25 +4,11 @@ import { UserService } from './user.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from 'src/entity/user.entity';
 import { AuthModule } from 'src/auth/auth.module';
-import { PlaylistService } from 'src/playlist/playlist.service';
-import { Playlist } from 'src/entity/playlist.entity';
-import { Music_Playlist } from 'src/entity/music_playlist.entity';
-import { Music } from 'src/entity/music.entity';
 import { Logger } from 'winston';
-import { Recent_Played } from 'src/entity/recent_played.entity';
 
 @Module({
-  imports: [
-    TypeOrmModule.forFeature([
-      User,
-      Playlist,
-      Music_Playlist,
-      Music,
-      Recent_Played,
-    ]),
-    AuthModule,
-  ],
+  imports: [TypeOrmModule.forFeature([User]), AuthModule],
   controllers: [UserController],
-  providers: [UserService, PlaylistService, Logger],
+  providers: [UserService, Logger],
 })
 export class UserModule {}

--- a/server/src/user/user.service.spec.ts
+++ b/server/src/user/user.service.spec.ts
@@ -3,42 +3,30 @@ import { UserService } from './user.service';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { User } from '../entity/user.entity';
-import { Playlist } from 'src/entity/playlist.entity';
-import { Music } from 'src/entity/music.entity';
-import { Music_Playlist } from 'src/entity/music_playlist.entity';
-import { PlaylistService } from 'src/playlist/playlist.service';
+import { Recent_Played } from 'src/entity/recent_played.entity';
+import { PassportModule } from '@nestjs/passport';
 
 describe('UserService', () => {
   let service: UserService;
-  let playlistService: PlaylistService;
   let userRepository: Repository<User>;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
+      imports: [PassportModule.register({ defaultStrategy: 'jwt' })],
       providers: [
         UserService,
-        PlaylistService,
         {
           provide: getRepositoryToken(User),
           useClass: Repository,
         },
         {
-          provide: getRepositoryToken(Playlist),
-          useClass: Repository,
-        },
-        {
-          provide: getRepositoryToken(Music),
-          useClass: Repository,
-        },
-        {
-          provide: getRepositoryToken(Music_Playlist),
+          provide: getRepositoryToken(Recent_Played),
           useClass: Repository,
         },
       ],
     }).compile();
 
     service = module.get<UserService>(UserService);
-    playlistService = module.get<PlaylistService>(PlaylistService);
     userRepository = module.get(getRepositoryToken(User));
   });
 

--- a/server/src/user/user.service.ts
+++ b/server/src/user/user.service.ts
@@ -4,16 +4,15 @@ import { User } from 'src/entity/user.entity';
 import { Music } from 'src/entity/music.entity';
 import { Repository } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
-import { PlaylistService } from 'src/playlist/playlist.service';
 import { CatchyException } from 'src/config/catchyException';
 import { ERROR_CODE } from 'src/config/errorCode.enum';
+import { Recent_Played } from 'src/entity/recent_played.entity';
 
 @Injectable()
 export class UserService {
   private readonly logger = new Logger('UserService');
   constructor(
     @InjectRepository(User) private userRepository: Repository<User>,
-    private playlistService: PlaylistService,
   ) {}
 
   async isDuplicatedUserEmail(userNickname: string): Promise<boolean> {
@@ -37,8 +36,22 @@ export class UserService {
     }
   }
 
-  async getRecentPlayedMusicByUserId(userId: string): Promise<Music[]> {
-    return await this.playlistService.getRecentMusicsByUserId(userId);
+  async getRecentPlayedMusicByUserId(
+    userId: string,
+    count: number,
+  ): Promise<Music[]> {
+    try {
+      return await Recent_Played.getRecentPlayedMusicByUserId(userId, count);
+    } catch {
+      this.logger.error(
+        `user.service - getRecentPlayedMusicByUserId : QUERY_ERROR`,
+      );
+      throw new CatchyException(
+        'QUERY_ERROR',
+        HTTP_STATUS_CODE.SERVER_ERROR,
+        ERROR_CODE.QUERY_ERROR,
+      );
+    }
   }
 
   async updateUserImage(user_id: string, image_url: string): Promise<string> {

--- a/server/src/user/user.service.ts
+++ b/server/src/user/user.service.ts
@@ -141,6 +141,16 @@ export class UserService {
 
   async updateRecentMusic(music_id: string, user_id: string): Promise<number> {
     try {
+      if (!(await Music.getMusicById(music_id))) {
+        this.logger.error(
+          `user.service - updateRecentMusic : NOT_EXIST_MUSIC_ID`,
+        );
+        throw new CatchyException(
+          'NOT_EXIST_MUSIC_ID',
+          HTTP_STATUS_CODE.BAD_REQUEST,
+          ERROR_CODE.NOT_EXIST_MUSIC_ID,
+        );
+      }
       if (!(await this.isExistMusicInRecentPlaylist(music_id, user_id))) {
         const newRow: Recent_Played = this.recentPlayedRepository.create({
           music: { music_id },

--- a/server/src/user/user.service.ts
+++ b/server/src/user/user.service.ts
@@ -129,7 +129,7 @@ export class UserService {
       return musicCount != 0;
     } catch {
       this.logger.error(
-        `playlist.service - isExistMusicInRecentPlaylist : QUERY_ERROR`,
+        `user.service - isExistMusicInRecentPlaylist : QUERY_ERROR`,
       );
       throw new CatchyException(
         'QUERY_ERROR',
@@ -163,9 +163,49 @@ export class UserService {
     } catch (err) {
       if (err instanceof CatchyException) throw err;
 
-      this.logger.error(`playlist.service - updateRecentMusic : SERVICE_ERROR`);
+      this.logger.error(`user.service - updateRecentMusic : SERVICE_ERROR`);
       throw new CatchyException(
         'SERVICE_ERROR',
+        HTTP_STATUS_CODE.SERVER_ERROR,
+        ERROR_CODE.QUERY_ERROR,
+      );
+    }
+  }
+
+  async getRecentPlaylistMusicCount(user_id: string): Promise<number> {
+    try {
+      return await this.recentPlayedRepository.count({
+        where: { user: { user_id } },
+      });
+    } catch {
+      this.logger.error(
+        `user.service - getRecentPlaylistMusicCount : QUERY_ERROR`,
+      );
+      throw new CatchyException(
+        'QUERY_ERROR',
+        HTTP_STATUS_CODE.SERVER_ERROR,
+        ERROR_CODE.QUERY_ERROR,
+      );
+    }
+  }
+
+  async getRecentPlaylistThumbnail(user_id: string): Promise<string> {
+    try {
+      const recentMusic: Recent_Played =
+        await this.recentPlayedRepository.findOne({
+          relations: { music: true, user: true },
+          select: { music: { cover: true } },
+          where: { user: { user_id } },
+          order: { played_at: 'DESC' },
+        });
+
+      return recentMusic.music.cover;
+    } catch {
+      this.logger.error(
+        `user.service - getRecentPlaylistThumbnail : QUERY_ERROR`,
+      );
+      throw new CatchyException(
+        'QUERY_ERROR',
         HTTP_STATUS_CODE.SERVER_ERROR,
         ERROR_CODE.QUERY_ERROR,
       );

--- a/server/src/user/user.service.ts
+++ b/server/src/user/user.service.ts
@@ -13,6 +13,8 @@ export class UserService {
   private readonly logger = new Logger('UserService');
   constructor(
     @InjectRepository(User) private userRepository: Repository<User>,
+    @InjectRepository(Recent_Played)
+    private recentPlayedRepository: Repository<Recent_Played>,
   ) {}
 
   async isDuplicatedUserEmail(userNickname: string): Promise<boolean> {
@@ -110,6 +112,60 @@ export class UserService {
       );
       throw new CatchyException(
         'QUERY_ERROR',
+        HTTP_STATUS_CODE.SERVER_ERROR,
+        ERROR_CODE.QUERY_ERROR,
+      );
+    }
+  }
+
+  async isExistMusicInRecentPlaylist(
+    music_id: string,
+    user_id: string,
+  ): Promise<boolean> {
+    try {
+      const musicCount: number = await this.recentPlayedRepository.count({
+        where: { music: { music_id }, user: { user_id } },
+      });
+      return musicCount != 0;
+    } catch {
+      this.logger.error(
+        `playlist.service - isExistMusicInRecentPlaylist : QUERY_ERROR`,
+      );
+      throw new CatchyException(
+        'QUERY_ERROR',
+        HTTP_STATUS_CODE.SERVER_ERROR,
+        ERROR_CODE.QUERY_ERROR,
+      );
+    }
+  }
+
+  async updateRecentMusic(music_id: string, user_id: string): Promise<number> {
+    try {
+      if (!(await this.isExistMusicInRecentPlaylist(music_id, user_id))) {
+        const newRow: Recent_Played = this.recentPlayedRepository.create({
+          music: { music_id },
+          user: { user_id },
+          played_at: new Date(),
+        });
+        const addedRow: Recent_Played =
+          await this.recentPlayedRepository.save(newRow);
+        return addedRow.recent_played_id;
+      }
+
+      const targetRow: Recent_Played =
+        await this.recentPlayedRepository.findOne({
+          where: { music: { music_id }, user: { user_id } },
+        });
+      targetRow.played_at = new Date();
+      const updatedRow: Recent_Played =
+        await this.recentPlayedRepository.save(targetRow);
+      return updatedRow.recent_played_id;
+    } catch (err) {
+      if (err instanceof CatchyException) throw err;
+
+      this.logger.error(`playlist.service - updateRecentMusic : SERVICE_ERROR`);
+      throw new CatchyException(
+        'SERVICE_ERROR',
         HTTP_STATUS_CODE.SERVER_ERROR,
         ERROR_CODE.QUERY_ERROR,
       );

--- a/server/test/constants/music.mockData.ts
+++ b/server/test/constants/music.mockData.ts
@@ -52,6 +52,7 @@ export const newMusicData: Music = {
     created_at: new Date(),
   } as User,
   music_playlist: [],
+  recent_played: [],
   hasId: () => true,
   save: async () => newMusicData,
   remove: async () => newMusicData,


### PR DESCRIPTION
## Issue
- #287 

## Overview
- Recent_Played 테이블 생성
- Music_Playlist 테이블 updated_at -> created_at 으로 필드명 변경
- 모든 최근 재생 목록 관련 API들 User 모듈로 이동
- `/user/recent-played` `PATCH` -> `PUT`
- `GET` `/user/recent-info` 음악 수, 썸네일 링크 응답하는 API 구현
- 불필요한 모듈 의존 관계 삭제

## Screenshot
- `GET` `/users/recent-info` 최근 재생 목록 정보 API
<img width="1392" alt="image" src="https://github.com/boostcampwm2023/and04-catchy-tape/assets/84065420/44becffa-4582-4733-aac9-fd24322fe2c6">

- `GET` `/users/recent-played` 최근 재생 목록 노래 정보 API
<img width="1392" alt="image" src="https://github.com/boostcampwm2023/and04-catchy-tape/assets/84065420/60294ff7-797e-4024-90bf-97dc6fbaa82a">


- `PUT` `/users/recent-played` 최근 재생 목록 노래 update
<img width="1392" alt="image" src="https://github.com/boostcampwm2023/and04-catchy-tape/assets/84065420/2b096e00-ce35-49e6-a907-156baf7aa9da">
