### PR TITLE
키보드가 보일 때, 화면이 보이지 않는 이슈 해결

### DIFF
--- a/android/app/src/main/java/com/ohdodok/catchytape/MainActivity.kt
+++ b/android/app/src/main/java/com/ohdodok/catchytape/MainActivity.kt
@@ -14,7 +14,6 @@ import androidx.core.view.WindowCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
-import androidx.media3.common.MediaItem
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.session.MediaController
 import androidx.media3.session.SessionToken
@@ -32,9 +31,7 @@ import com.ohdodok.catchytape.feature.player.movePreviousMedia
 import com.ohdodok.catchytape.feature.player.navigateToPlayer
 import com.ohdodok.catchytape.mediasession.PlaybackService
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.channels.consumeEach
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.launch
 import javax.inject.Inject

--- a/android/core/ui/src/main/java/com/ohdodok/catchytape/core/ui/RootViewInsetsCallback.kt
+++ b/android/core/ui/src/main/java/com/ohdodok/catchytape/core/ui/RootViewInsetsCallback.kt
@@ -1,0 +1,18 @@
+package com.ohdodok.catchytape.core.ui
+
+import android.os.Build
+import android.view.View
+import androidx.annotation.RequiresApi
+import androidx.core.view.WindowInsetsCompat
+
+class RootViewInsetsCallback : androidx.core.view.OnApplyWindowInsetsListener {
+    @RequiresApi(Build.VERSION_CODES.R)
+    override fun onApplyWindowInsets(view: View, insets: WindowInsetsCompat): WindowInsetsCompat {
+        val systemBar = WindowInsetsCompat.Type.systemBars()
+
+        val typeInsets = insets.getInsets(systemBar)
+        view.setPadding(typeInsets.left, typeInsets.top, typeInsets.right, 0)
+
+        return WindowInsetsCompat.CONSUMED
+    }
+}

--- a/android/feature/home/src/main/java/com/ohdodok/catchytape/feature/home/HomeFragment.kt
+++ b/android/feature/home/src/main/java/com/ohdodok/catchytape/feature/home/HomeFragment.kt
@@ -3,6 +3,7 @@ package com.ohdodok.catchytape.feature.home
 import android.os.Bundle
 import android.view.View
 import androidx.core.net.toUri
+import androidx.core.view.ViewCompat
 import androidx.fragment.app.viewModels
 import androidx.navigation.NavController
 import androidx.navigation.NavDeepLinkRequest
@@ -10,6 +11,7 @@ import androidx.navigation.fragment.findNavController
 import com.ohdodok.catchytape.core.ui.BaseFragment
 import com.ohdodok.catchytape.core.ui.MusicAdapter
 import com.ohdodok.catchytape.core.ui.Orientation
+import com.ohdodok.catchytape.core.ui.RootViewInsetsCallback
 import com.ohdodok.catchytape.core.ui.toMessageId
 import com.ohdodok.catchytape.feature.home.databinding.FragmentHomeBinding
 import dagger.hilt.android.AndroidEntryPoint
@@ -21,6 +23,9 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root, RootViewInsetsCallback())
+
         binding.viewModel = viewModel
 
         binding.rvRecentlyAddedSong.adapter = MusicAdapter(

--- a/android/feature/home/src/main/res/layout/fragment_home.xml
+++ b/android/feature/home/src/main/res/layout/fragment_home.xml
@@ -17,7 +17,6 @@
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:fitsSystemWindows="true"
             android:paddingBottom="32dp">
 
             <com.google.android.material.appbar.MaterialToolbar

--- a/android/feature/mypage/src/main/java/com/ohdodok/catchytape/feature/mypage/MyMusicsFragment.kt
+++ b/android/feature/mypage/src/main/java/com/ohdodok/catchytape/feature/mypage/MyMusicsFragment.kt
@@ -2,10 +2,12 @@ package com.ohdodok.catchytape.feature.mypage
 
 import android.os.Bundle
 import android.view.View
+import androidx.core.view.ViewCompat
 import androidx.fragment.app.viewModels
 import com.ohdodok.catchytape.core.ui.BaseFragment
 import com.ohdodok.catchytape.core.ui.MusicAdapter
 import com.ohdodok.catchytape.core.ui.Orientation
+import com.ohdodok.catchytape.core.ui.RootViewInsetsCallback
 import com.ohdodok.catchytape.core.ui.toMessageId
 import com.ohdodok.catchytape.feature.mypage.databinding.FragmentMyMusicsBinding
 import dagger.hilt.android.AndroidEntryPoint
@@ -16,6 +18,8 @@ class MyMusicsFragment : BaseFragment<FragmentMyMusicsBinding>(R.layout.fragment
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root, RootViewInsetsCallback())
         binding.viewModel = viewModel
 
         setupRecyclerView()

--- a/android/feature/mypage/src/main/java/com/ohdodok/catchytape/feature/mypage/MyPageFragment.kt
+++ b/android/feature/mypage/src/main/java/com/ohdodok/catchytape/feature/mypage/MyPageFragment.kt
@@ -2,11 +2,13 @@ package com.ohdodok.catchytape.feature.mypage
 
 import android.os.Bundle
 import android.view.View
+import androidx.core.view.ViewCompat
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.ohdodok.catchytape.core.ui.BaseFragment
 import com.ohdodok.catchytape.core.ui.MusicAdapter
 import com.ohdodok.catchytape.core.ui.Orientation
+import com.ohdodok.catchytape.core.ui.RootViewInsetsCallback
 import com.ohdodok.catchytape.core.ui.toMessageId
 import com.ohdodok.catchytape.feature.mypage.databinding.FragmentMyPageBinding
 import dagger.hilt.android.AndroidEntryPoint
@@ -18,6 +20,7 @@ class MyPageFragment : BaseFragment<FragmentMyPageBinding>(R.layout.fragment_my_
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root, RootViewInsetsCallback())
         binding.viewModel = viewModel
 
         observeEvents()

--- a/android/feature/mypage/src/main/res/layout/fragment_my_musics.xml
+++ b/android/feature/mypage/src/main/res/layout/fragment_my_musics.xml
@@ -12,8 +12,7 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:fitsSystemWindows="true">
+        android:layout_height="match_parent">
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/tb_my_musics"

--- a/android/feature/mypage/src/main/res/layout/fragment_my_page.xml
+++ b/android/feature/mypage/src/main/res/layout/fragment_my_page.xml
@@ -12,8 +12,7 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:fitsSystemWindows="true">
+        android:layout_height="match_parent">
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/tb_my_page"

--- a/android/feature/player/src/main/java/com/ohdodok/catchytape/feature/player/PlayerFragment.kt
+++ b/android/feature/player/src/main/java/com/ohdodok/catchytape/feature/player/PlayerFragment.kt
@@ -3,11 +3,13 @@ package com.ohdodok.catchytape.feature.player
 import android.os.Bundle
 import android.view.View
 import android.widget.SeekBar
+import androidx.core.view.ViewCompat
 import androidx.fragment.app.activityViewModels
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.navigation.NavController
 import androidx.navigation.fragment.findNavController
 import com.ohdodok.catchytape.core.ui.BaseFragment
+import com.ohdodok.catchytape.core.ui.RootViewInsetsCallback
 import com.ohdodok.catchytape.core.ui.toMessageId
 import com.ohdodok.catchytape.feature.player.databinding.FragmentPlayerBinding
 import dagger.hilt.android.AndroidEntryPoint
@@ -24,6 +26,8 @@ class PlayerFragment : BaseFragment<FragmentPlayerBinding>(R.layout.fragment_pla
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root, RootViewInsetsCallback())
         binding.viewModel = viewModel
 
         setUpSeekBar()

--- a/android/feature/player/src/main/res/layout/fragment_player.xml
+++ b/android/feature/player/src/main/res/layout/fragment_player.xml
@@ -14,8 +14,7 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:fitsSystemWindows="true">
+        android:layout_height="match_parent">
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/tb_player"

--- a/android/feature/playlist/src/main/java/com/ohdodok/catchytape/feature/playlist/PlaylistsFragment.kt
+++ b/android/feature/playlist/src/main/java/com/ohdodok/catchytape/feature/playlist/PlaylistsFragment.kt
@@ -2,11 +2,13 @@ package com.ohdodok.catchytape.feature.playlist
 
 import android.os.Bundle
 import android.view.View
+import androidx.core.view.ViewCompat
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.NavController
 import androidx.navigation.fragment.findNavController
 import com.ohdodok.catchytape.core.ui.BaseFragment
+import com.ohdodok.catchytape.core.ui.RootViewInsetsCallback
 import com.ohdodok.catchytape.core.ui.toMessageId
 import com.ohdodok.catchytape.feature.playlist.databinding.FragmentPlaylistsBinding
 import dagger.hilt.android.AndroidEntryPoint
@@ -19,6 +21,7 @@ class PlaylistsFragment : BaseFragment<FragmentPlaylistsBinding>(R.layout.fragme
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root, RootViewInsetsCallback())
         binding.viewModel = viewModel
         binding.rvPlaylist.adapter = PlaylistAdapter()
         viewModel.fetchPlaylists()

--- a/android/feature/playlist/src/main/res/layout/fragment_playlists.xml
+++ b/android/feature/playlist/src/main/res/layout/fragment_playlists.xml
@@ -13,8 +13,7 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:fitsSystemWindows="true">
+        android:layout_height="match_parent">
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/rv_playlist"

--- a/android/feature/search/src/main/java/com/ohdodok/catchytape/feature/search/SearchFragment.kt
+++ b/android/feature/search/src/main/java/com/ohdodok/catchytape/feature/search/SearchFragment.kt
@@ -1,15 +1,13 @@
 package com.ohdodok.catchytape.feature.search
 
-import android.os.Build
 import android.os.Bundle
 import android.view.View
-import androidx.annotation.RequiresApi
 import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
 import androidx.fragment.app.viewModels
 import com.ohdodok.catchytape.core.ui.BaseFragment
 import com.ohdodok.catchytape.core.ui.MusicAdapter
 import com.ohdodok.catchytape.core.ui.Orientation
+import com.ohdodok.catchytape.core.ui.RootViewInsetsCallback
 import com.ohdodok.catchytape.core.ui.toMessageId
 import com.ohdodok.catchytape.feature.search.databinding.FragmentSearchBinding
 import dagger.hilt.android.AndroidEntryPoint
@@ -48,16 +46,4 @@ class SearchFragment : BaseFragment<FragmentSearchBinding>(R.layout.fragment_sea
         }
     }
 
-}
-
-class RootViewInsetsCallback : androidx.core.view.OnApplyWindowInsetsListener {
-    @RequiresApi(Build.VERSION_CODES.R)
-    override fun onApplyWindowInsets(view: View, insets: WindowInsetsCompat): WindowInsetsCompat {
-        val systemBar = WindowInsetsCompat.Type.systemBars()
-
-        val typeInsets = insets.getInsets(systemBar)
-        view.setPadding(typeInsets.left, typeInsets.top, typeInsets.right, typeInsets.bottom)
-
-        return WindowInsetsCompat.CONSUMED
-    }
 }

--- a/android/feature/search/src/main/java/com/ohdodok/catchytape/feature/search/SearchFragment.kt
+++ b/android/feature/search/src/main/java/com/ohdodok/catchytape/feature/search/SearchFragment.kt
@@ -1,7 +1,11 @@
 package com.ohdodok.catchytape.feature.search
 
+import android.os.Build
 import android.os.Bundle
 import android.view.View
+import androidx.annotation.RequiresApi
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.fragment.app.viewModels
 import com.ohdodok.catchytape.core.ui.BaseFragment
 import com.ohdodok.catchytape.core.ui.MusicAdapter
@@ -18,10 +22,14 @@ class SearchFragment : BaseFragment<FragmentSearchBinding>(R.layout.fragment_sea
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root, RootViewInsetsCallback())
+
         binding.viewModel = viewModel
 
         observeEvents()
         setupRecyclerView()
+
     }
 
     private fun setupRecyclerView() {
@@ -40,4 +48,16 @@ class SearchFragment : BaseFragment<FragmentSearchBinding>(R.layout.fragment_sea
         }
     }
 
+}
+
+class RootViewInsetsCallback : androidx.core.view.OnApplyWindowInsetsListener {
+    @RequiresApi(Build.VERSION_CODES.R)
+    override fun onApplyWindowInsets(view: View, insets: WindowInsetsCompat): WindowInsetsCompat {
+        val systemBar = WindowInsetsCompat.Type.systemBars()
+
+        val typeInsets = insets.getInsets(systemBar)
+        view.setPadding(typeInsets.left, typeInsets.top, typeInsets.right, typeInsets.bottom)
+
+        return WindowInsetsCompat.CONSUMED
+    }
 }

--- a/android/feature/search/src/main/res/layout/fragment_search.xml
+++ b/android/feature/search/src/main/res/layout/fragment_search.xml
@@ -12,8 +12,7 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:fitsSystemWindows="true">
+        android:layout_height="match_parent">
 
         <EditText
             android:id="@+id/et_search"

--- a/android/feature/upload/src/main/java/com/ohdodok/catchytape/feature/upload/UploadFragment.kt
+++ b/android/feature/upload/src/main/java/com/ohdodok/catchytape/feature/upload/UploadFragment.kt
@@ -7,6 +7,7 @@ import android.view.View
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia
+import androidx.core.view.ViewCompat
 import androidx.databinding.BindingAdapter
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
@@ -14,6 +15,7 @@ import com.google.android.material.textfield.TextInputLayout
 import com.ohdodok.catchytape.catchytape.upload.R
 import com.ohdodok.catchytape.catchytape.upload.databinding.FragmentUploadBinding
 import com.ohdodok.catchytape.core.ui.BaseFragment
+import com.ohdodok.catchytape.core.ui.RootViewInsetsCallback
 import com.ohdodok.catchytape.core.ui.toMessageId
 import dagger.hilt.android.AndroidEntryPoint
 import java.io.File
@@ -37,6 +39,8 @@ class UploadFragment : BaseFragment<FragmentUploadBinding>(R.layout.fragment_upl
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root, RootViewInsetsCallback())
         binding.viewModel = viewModel
 
         observeEvents()

--- a/android/feature/upload/src/main/res/layout/fragment_upload.xml
+++ b/android/feature/upload/src/main/res/layout/fragment_upload.xml
@@ -15,8 +15,7 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:fitsSystemWindows="true">
+        android:layout_height="match_parent">
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/tb_upload"


### PR DESCRIPTION
## Issue
- #289

## Overview
키보드가 보일 때, 화면이 보이지 않는 이슈 해결

## To Reviewers 
스크린 영역을 확장하면서 activity의 fitsSystemWindow를 false 로 설정해줬었음.
fitsSystemWindow 가 true 면 system window의 padding 이 적용되는데, false 를 하면 padding이 적용되지 않음.
fitsSystemWindows="true" 설정하면 기본 값 insets를 적용하면서 시스템 영역(상태바, 네비게이션 바)를 가리지 않게 해줌.
확장 스크린을 쓰지 않는 뷰에서는 rootview 에 android:fitsSystemWindows="true" 를 설정해었는데 
상태바, 네비게이션 바 의 패딩 값을 주게되어 불필요한 네비게이션 바의 패딩을 가지게 됌.
뿐만아니라 fitsSystemWindows="true" 면 키보드가 올라올 때 키보드 높이만큼 공간을 차지하게 됌
그래서 view 에 [OnApplyWindowInsetsListener](https://developer.android.com/reference/android/support/v4/view/OnApplyWindowInsetsListener?hl=ko) 를 적용하여 뷰의 패딩을 업데이트 해줌.
[참고블로그](https://sungbin.land/%EC%95%88%EB%93%9C%EB%A1%9C%EC%9D%B4%EB%93%9C-windowinsets%EC%9C%BC%EB%A1%9C-%ED%82%A4%EB%B3%B4%EB%93%9C-%EC%95%A0%EB%8B%88%EB%A9%94%EC%9D%B4%EC%85%98-%EA%B5%AC%ED%98%84%ED%95%98%EA%B8%B0-2-fcfc87683401)


확장 스크린을 적용하지 않는 경우에는 새로 생성한 클래스 RootViewInsetsCallback() 를 사용해야합니당!