### PR TITLE
DB 인덱스 추가 + 도커 컨테이너 타임존 설정

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:20
 
+ENV TZ=Asia/Seoul
+
 WORKDIR /catchy-tape
 
 COPY . .

--- a/server/src/entity/music.entity.ts
+++ b/server/src/entity/music.entity.ts
@@ -8,6 +8,7 @@ import {
   OneToMany,
   PrimaryColumn,
   ILike,
+  Index,
 } from 'typeorm';
 import { User } from './user.entity';
 import { Genres } from 'src/constants';
@@ -35,6 +36,7 @@ export class Music extends BaseEntity {
   genre: Genres;
 
   @CreateDateColumn()
+  @Index()
   created_at: Date;
 
   @ManyToOne(() => User, (user) => user.musics)

--- a/server/src/entity/music_playlist.entity.ts
+++ b/server/src/entity/music_playlist.entity.ts
@@ -2,6 +2,7 @@ import {
   BaseEntity,
   Column,
   Entity,
+  Index,
   JoinColumn,
   ManyToOne,
   PrimaryGeneratedColumn,
@@ -20,9 +21,11 @@ export class Music_Playlist extends BaseEntity {
 
   @ManyToOne(() => Playlist, (playlist) => playlist.music_playlist)
   @JoinColumn({ name: 'playlist_id' })
+  @Index()
   playlist: Playlist;
 
   @Column()
+  @Index()
   created_at: Date;
 
   static async getMusicListByPlaylistId(playlistId: number): Promise<Music[]> {

--- a/server/src/entity/playlist.entity.ts
+++ b/server/src/entity/playlist.entity.ts
@@ -3,6 +3,7 @@ import {
   Column,
   CreateDateColumn,
   Entity,
+  Index,
   JoinColumn,
   ManyToOne,
   OneToMany,
@@ -27,6 +28,7 @@ export class Playlist extends BaseEntity {
 
   @ManyToOne(() => User, (user) => user.playlists)
   @JoinColumn({ name: 'user_id' })
+  @Index()
   user: User;
 
   @OneToMany(() => Music_Playlist, (music_playlist) => music_playlist.playlist)

--- a/server/src/entity/recent_played.entity.ts
+++ b/server/src/entity/recent_played.entity.ts
@@ -2,6 +2,7 @@ import {
   BaseEntity,
   Column,
   Entity,
+  Index,
   JoinColumn,
   ManyToOne,
   PrimaryGeneratedColumn,
@@ -10,6 +11,7 @@ import { Music } from './music.entity';
 import { User } from './user.entity';
 
 @Entity({ name: 'recent_played' })
+@Index(['user', 'music'])
 export class Recent_Played extends BaseEntity {
   @PrimaryGeneratedColumn()
   recent_played_id: number;
@@ -23,6 +25,7 @@ export class Recent_Played extends BaseEntity {
   user: User;
 
   @Column()
+  @Index()
   played_at: Date;
 
   static async getRecentPlayedMusicByUserId(

--- a/server/src/user/user.service.ts
+++ b/server/src/user/user.service.ts
@@ -177,7 +177,7 @@ export class UserService {
       throw new CatchyException(
         'SERVICE_ERROR',
         HTTP_STATUS_CODE.SERVER_ERROR,
-        ERROR_CODE.QUERY_ERROR,
+        ERROR_CODE.SERVICE_ERROR,
       );
     }
   }


### PR DESCRIPTION
## Issue
- #288 

## Overview
- 정했던 컬럼에 대해서 인덱스 추가
- 도커 컨테이너 타임존 서울로 변경

## Screenshot 
- 인덱스
<img width="1312" alt="image" src="https://github.com/boostcampwm2023/and04-catchy-tape/assets/84065420/d8a6e89e-da3b-41e7-bf73-7ef0d7408978">

- 컨테이너 시간
<img width="902" alt="image" src="https://github.com/boostcampwm2023/and04-catchy-tape/assets/84065420/20a23afc-aa73-4ce3-8354-4952e92d7f3e">

