### PR TITLE
백그라운드에서 노래 재생 관리

### DIFF
--- a/android/app/src/main/java/com/ohdodok/catchytape/mediasession/PlaybackService.kt
+++ b/android/app/src/main/java/com/ohdodok/catchytape/mediasession/PlaybackService.kt
@@ -1,5 +1,6 @@
 package com.ohdodok.catchytape.mediasession
 
+import android.content.Intent
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.session.MediaSession
 import androidx.media3.session.MediaSessionService
@@ -24,6 +25,11 @@ class PlaybackService : MediaSessionService()  {
             mediaSession = null
         }
         super.onDestroy()
+    }
+
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        player.pause()
+        stopSelf()
     }
 
     override fun onGetSession(


### PR DESCRIPTION
## Issue
- #123 

## Overview
- 앱이 완전히 종료되면 Service를 종료시킨다.


## 테스트

- 무음 모드에서는 전화가 와도 계속 재생 됨
- 소리 모드에서는 전화가 오면 전화 벨소리가 들리고, 음악을 중지 됨
