### PR TITLE
음악을 재생목록에 추가할 때 발생하는 이슈 처리

### DIFF
--- a/android/app/src/main/java/com/ohdodok/catchytape/MainActivity.kt
+++ b/android/app/src/main/java/com/ohdodok/catchytape/MainActivity.kt
@@ -102,7 +102,8 @@ class MainActivity : AppCompatActivity() {
 
         navHostFragment.findNavController().addOnDestinationChangedListener { _, destination, _ ->
             when (destination.id) {
-                com.ohdodok.catchytape.feature.player.R.id.player_fragment -> {
+                com.ohdodok.catchytape.feature.player.R.id.player_fragment,
+                com.ohdodok.catchytape.feature.player.R.id.playlist_bottom_sheet -> {
                     hideBottomNav()
                     hidePlayerController()
                 }

--- a/android/core/ui/src/main/java/com/ohdodok/catchytape/core/ui/PlaylistBottomSheet.kt
+++ b/android/core/ui/src/main/java/com/ohdodok/catchytape/core/ui/PlaylistBottomSheet.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.annotation.StringRes
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
@@ -11,7 +12,6 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
-import com.google.android.material.snackbar.Snackbar
 import com.ohdodok.catchytape.core.ui.cterror.toMessageId
 import com.ohdodok.catchytape.core.ui.databinding.BottomSheetPlaylistBinding
 import dagger.hilt.android.AndroidEntryPoint
@@ -44,7 +44,8 @@ class PlaylistBottomSheet : BottomSheetDialogFragment() {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.events.collect { event ->
                     when (event) {
-                        is PlaylistBottomSheetEvent.Close -> {
+                        is PlaylistBottomSheetEvent.Success -> {
+                            showMessage(R.string.add_to_playlist_success)
                             findNavController().popBackStack()
                         }
 
@@ -58,7 +59,7 @@ class PlaylistBottomSheet : BottomSheetDialogFragment() {
     }
 
     private fun showMessage(@StringRes messageId: Int) {
-        Snackbar.make(this.requireView(), messageId, Snackbar.LENGTH_LONG).show()
+        Toast.makeText(requireActivity(), messageId, Toast.LENGTH_SHORT).show()
     }
 
     override fun onDestroyView() {

--- a/android/core/ui/src/main/java/com/ohdodok/catchytape/core/ui/PlaylistBottomSheetViewModel.kt
+++ b/android/core/ui/src/main/java/com/ohdodok/catchytape/core/ui/PlaylistBottomSheetViewModel.kt
@@ -21,7 +21,7 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 sealed interface PlaylistBottomSheetEvent {
-    data object Close : PlaylistBottomSheetEvent
+    data object Success : PlaylistBottomSheetEvent
     data class ShowMessage(val error: CtErrorType) : PlaylistBottomSheetEvent
 }
 
@@ -62,7 +62,7 @@ class PlaylistBottomSheetViewModel @Inject constructor(
     private fun addMusicToPlaylist(playlistId: Int, musicId: String) {
         viewModelScope.launch(exceptionHandler) {
             playlistRepository.addMusicToPlaylist(playlistId = playlistId, musicId = musicId)
-            _events.emit(PlaylistBottomSheetEvent.Close)
+            _events.emit(PlaylistBottomSheetEvent.Success)
         }
     }
 

--- a/android/core/ui/src/main/java/com/ohdodok/catchytape/core/ui/PlaylistBottomSheetViewModel.kt
+++ b/android/core/ui/src/main/java/com/ohdodok/catchytape/core/ui/PlaylistBottomSheetViewModel.kt
@@ -3,6 +3,7 @@ package com.ohdodok.catchytape.core.ui
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.ohdodok.catchytape.core.domain.model.CtErrorType
 import com.ohdodok.catchytape.core.domain.model.Playlist
 import com.ohdodok.catchytape.core.domain.repository.PlaylistRepository
 import com.ohdodok.catchytape.core.ui.model.PlaylistUiModel
@@ -17,6 +18,11 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+sealed interface PlaylistBottomSheetEvent {
+    data object Close : PlaylistBottomSheetEvent
+    data class ShowMessage(val error: CtErrorType) : PlaylistBottomSheetEvent
+}
+
 @HiltViewModel
 class PlaylistBottomSheetViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
@@ -30,8 +36,8 @@ class PlaylistBottomSheetViewModel @Inject constructor(
     private val _playlists = MutableStateFlow(emptyList<PlaylistUiModel>())
     val playlists: StateFlow<List<PlaylistUiModel>> = _playlists.asStateFlow()
 
-    private val _closeEvent = MutableSharedFlow<Unit>()
-    val closeEvent: SharedFlow<Unit> = _closeEvent.asSharedFlow()
+    private val _events = MutableSharedFlow<PlaylistBottomSheetEvent>()
+    val events: SharedFlow<PlaylistBottomSheetEvent> = _events.asSharedFlow()
 
     init {
         fetchPlaylists()
@@ -46,7 +52,7 @@ class PlaylistBottomSheetViewModel @Inject constructor(
     private fun addMusicToPlaylist(playlistId: Int, musicId: String) {
         viewModelScope.launch {
             playlistRepository.addMusicToPlaylist(playlistId = playlistId, musicId = musicId)
-            _closeEvent.emit(Unit)
+            _events.emit(PlaylistBottomSheetEvent.Close)
         }
     }
 

--- a/android/core/ui/src/main/res/values/strings.xml
+++ b/android/core/ui/src/main/res/values/strings.xml
@@ -48,7 +48,7 @@
     <string name="error_message_server">서버가 작업 중이에요. 잠시만 기다려주세요.</string>
     <string name="error_message_not_exist_playlist_on_user">"error_message_not_exist_playlist_on_user"</string>
     <string name="error_message_not_exist_music">"error_message_not_exist_music"</string>
-    <string name="error_message_already_added">"error_message_already_added"</string>
+    <string name="error_message_already_added">이미 추가된 음악이에요.</string>
     <string name="error_message_invalid_input_value">"error_message_invalid_input_value"</string>
     <string name="error_message_not_exist_user">"error_message_not_exist_user"</string>
     <string name="error_message_already_exist_email">이미 회원가입이 완료된 이메일이에요 !</string>

--- a/android/core/ui/src/main/res/values/strings.xml
+++ b/android/core/ui/src/main/res/values/strings.xml
@@ -37,6 +37,7 @@
     <string name="track_size">트랙 %d개</string>
 
     <string name="add_to_playlist">재생 목록에 노래 추가</string>
+    <string name="add_to_playlist_success">노래를 추가했어요.</string>
 
     <string name="error_message_connection">"error_message_connection"</string>
     <string name="error_message_ssl_hand_shake">"error_message_ssl_hand_shake"</string>


### PR DESCRIPTION
## Issue
- #298 

## Overview
- Fragment를 띄우면 하단 재생 바가 자기 부른 줄 알고 같이 올라옴 (해결)
- 예외 처리(이미 추가된 노래일 경우 등)가 안 되어 있음 (해결)
- 정상적으로 추가되면 알림 메시지를 띄워줘야 함 (해결)
- 이유는 모르겠으나 바텀 시트가 떠 있는 동안 재생 버튼이 사라짐 (미결)
- UI radius 추가하거나 디자인을 바꿔야 함 (미결)
- 사진 썸네일이 짤리는 현상 (미결)

## To Reviewers
중요한 이슈 먼저 해결했어
