### PR TITLE
QA에서 발견한 버그 개선 및 MyPage -> Player 이동

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -15,7 +15,8 @@
         android:usesCleartextTraffic="true">
         <activity
             android:name=".feature.login.LoginActivity"
-            android:exported="true">
+            android:exported="true"
+            android:screenOrientation="portrait">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
@@ -25,7 +26,8 @@
 
         <activity
             android:name=".MainActivity"
-            android:exported="true" />
+            android:exported="true"
+            android:screenOrientation="portrait" />
 
         <service
             android:name=".mediasession.PlaybackService"

--- a/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/utils/CoroutineUtils.kt
+++ b/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/utils/CoroutineUtils.kt
@@ -3,19 +3,13 @@ package com.ohdodok.catchytape.core.domain.utils
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
-fun <T> Flow<T>.throttleFist(windowDuration: Long): Flow<T> = flow {
-    var windowStartTime = System.currentTimeMillis()
-    var emitted = false
-    collect { value ->
+fun <T> Flow<T>.throttleFirst(windowDuration: Long): Flow<T> = flow {
+    var lastEmissionTime = 0L
+    collect { upstream ->
         val currentTime = System.currentTimeMillis()
-        val delta = currentTime - windowStartTime
-        if (delta >= windowDuration) {
-            windowStartTime += delta / windowDuration * windowDuration
-            emitted = false
-        }
-        if (!emitted) {
-            emit(value)
-            emitted = true
+        if (currentTime - lastEmissionTime > windowDuration) {
+            lastEmissionTime = currentTime
+            emit(upstream)
         }
     }
 }

--- a/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/utils/CoroutineUtils.kt
+++ b/android/core/domain/src/main/java/com/ohdodok/catchytape/core/domain/utils/CoroutineUtils.kt
@@ -1,0 +1,21 @@
+package com.ohdodok.catchytape.core.domain.utils
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+fun <T> Flow<T>.throttleFist(windowDuration: Long): Flow<T> = flow {
+    var windowStartTime = System.currentTimeMillis()
+    var emitted = false
+    collect { value ->
+        val currentTime = System.currentTimeMillis()
+        val delta = currentTime - windowStartTime
+        if (delta >= windowDuration) {
+            windowStartTime += delta / windowDuration * windowDuration
+            emitted = false
+        }
+        if (!emitted) {
+            emit(value)
+            emitted = true
+        }
+    }
+}

--- a/android/core/ui/src/main/java/com/ohdodok/catchytape/core/ui/BaseFragment.kt
+++ b/android/core/ui/src/main/java/com/ohdodok/catchytape/core/ui/BaseFragment.kt
@@ -17,6 +17,9 @@ import androidx.navigation.fragment.findNavController
 import com.google.android.material.appbar.MaterialToolbar
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.launch
 
 abstract class BaseFragment<VB : ViewDataBinding>(
@@ -41,7 +44,7 @@ abstract class BaseFragment<VB : ViewDataBinding>(
         _binding = null
     }
 
-    protected fun setupBackStack(toolbar: MaterialToolbar){
+    protected fun setupBackStack(toolbar: MaterialToolbar) {
         toolbar.setNavigationOnClickListener {
             findNavController().popBackStack()
         }
@@ -55,6 +58,11 @@ abstract class BaseFragment<VB : ViewDataBinding>(
 
     protected fun showMessage(@StringRes messageId: Int) {
         Snackbar.make(this.requireView(), messageId, Snackbar.LENGTH_LONG).show()
+    }
+
+    protected fun clicksFlow(view: View): Flow<Unit> = callbackFlow {
+        view.setOnClickListener { trySend(Unit) }
+        awaitClose { view.setOnClickListener(null) }
     }
 
 }

--- a/android/core/ui/src/main/java/com/ohdodok/catchytape/core/ui/BaseFragment.kt
+++ b/android/core/ui/src/main/java/com/ohdodok/catchytape/core/ui/BaseFragment.kt
@@ -17,9 +17,6 @@ import androidx.navigation.fragment.findNavController
 import com.google.android.material.appbar.MaterialToolbar
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.channels.awaitClose
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.launch
 
 abstract class BaseFragment<VB : ViewDataBinding>(
@@ -59,10 +56,4 @@ abstract class BaseFragment<VB : ViewDataBinding>(
     protected fun showMessage(@StringRes messageId: Int) {
         Snackbar.make(this.requireView(), messageId, Snackbar.LENGTH_LONG).show()
     }
-
-    protected fun clicksFlow(view: View): Flow<Unit> = callbackFlow {
-        view.setOnClickListener { trySend(Unit) }
-        awaitClose { view.setOnClickListener(null) }
-    }
-
 }

--- a/android/core/ui/src/main/java/com/ohdodok/catchytape/core/ui/ViewUtils.kt
+++ b/android/core/ui/src/main/java/com/ohdodok/catchytape/core/ui/ViewUtils.kt
@@ -1,0 +1,11 @@
+package com.ohdodok.catchytape.core.ui
+
+import android.view.View
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+
+fun View.clicksFlow(): Flow<Unit> = callbackFlow {
+    setOnClickListener { trySend(Unit) }
+    awaitClose { setOnClickListener(null) }
+}

--- a/android/core/ui/src/main/res/layout/bottom_sheet_playlist.xml
+++ b/android/core/ui/src/main/res/layout/bottom_sheet_playlist.xml
@@ -4,6 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
+
         <variable
             name="viewModel"
             type="com.ohdodok.catchytape.core.ui.PlaylistBottomSheetViewModel" />
@@ -11,7 +12,7 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="match_parent"
         android:background="@color/surface_bright">
 
         <TextView
@@ -43,11 +44,9 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
             android:layout_marginBottom="8dp"
-            android:maxHeight="400dp"
             android:orientation="vertical"
             android:paddingHorizontal="@dimen/margin_horizontal"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/divider"

--- a/android/feature/home/src/main/java/com/ohdodok/catchytape/feature/home/HomeFragment.kt
+++ b/android/feature/home/src/main/java/com/ohdodok/catchytape/feature/home/HomeFragment.kt
@@ -69,5 +69,5 @@ private fun NavController.navigateToPlayerScreen() {
         NavDeepLinkRequest.Builder.fromUri("android-app://com.ohdodok.catchytape/player_fragment".toUri())
             .build()
 
-    this.navigate(request)
+    navigate(request)
 }

--- a/android/feature/mypage/src/main/java/com/ohdodok/catchytape/feature/mypage/MyMusicsFragment.kt
+++ b/android/feature/mypage/src/main/java/com/ohdodok/catchytape/feature/mypage/MyMusicsFragment.kt
@@ -2,8 +2,12 @@ package com.ohdodok.catchytape.feature.mypage
 
 import android.os.Bundle
 import android.view.View
+import androidx.core.net.toUri
 import androidx.core.view.ViewCompat
 import androidx.fragment.app.viewModels
+import androidx.navigation.NavController
+import androidx.navigation.NavDeepLinkRequest
+import androidx.navigation.fragment.findNavController
 import com.ohdodok.catchytape.core.ui.BaseFragment
 import com.ohdodok.catchytape.core.ui.MusicAdapter
 import com.ohdodok.catchytape.core.ui.Orientation
@@ -28,7 +32,10 @@ class MyMusicsFragment : BaseFragment<FragmentMyMusicsBinding>(R.layout.fragment
     }
 
     private fun setupRecyclerView() {
-        binding.rvMyMusics.adapter = MusicAdapter(Orientation.VERTICAL)
+        binding.rvMyMusics.adapter = MusicAdapter(
+            musicItemOrientation = Orientation.VERTICAL,
+            listener = viewModel
+        )
     }
 
     private fun observeEvents() {
@@ -38,8 +45,17 @@ class MyMusicsFragment : BaseFragment<FragmentMyMusicsBinding>(R.layout.fragment
                     is MyMusicsEvent.ShowMessage -> {
                         showMessage(event.error.toMessageId())
                     }
+                    is MyMusicsEvent.NavigateToPlayerScreen -> {
+                        findNavController().navigateToPlayerScreen()
+                    }
                 }
             }
         }
     }
+}
+
+private fun NavController.navigateToPlayerScreen() {
+    val request =
+        NavDeepLinkRequest.Builder.fromUri("android-app://com.ohdodok.catchytape/player_fragment".toUri()).build()
+    navigate(request)
 }

--- a/android/feature/mypage/src/main/java/com/ohdodok/catchytape/feature/mypage/MyPageFragment.kt
+++ b/android/feature/mypage/src/main/java/com/ohdodok/catchytape/feature/mypage/MyPageFragment.kt
@@ -5,6 +5,7 @@ import android.view.View
 import androidx.core.net.toUri
 import androidx.core.view.ViewCompat
 import androidx.fragment.app.viewModels
+import androidx.navigation.NavController
 import androidx.navigation.NavDeepLinkRequest
 import androidx.navigation.fragment.findNavController
 import com.ohdodok.catchytape.core.ui.BaseFragment
@@ -37,6 +38,9 @@ class MyPageFragment : BaseFragment<FragmentMyPageBinding>(R.layout.fragment_my_
                     is MyPageEvent.ShowMessage -> {
                         showMessage(event.error.toMessageId())
                     }
+                    is MyPageEvent.NavigateToPlayerScreen -> {
+                        findNavController().navigateToPlayerScreen()
+                    }
                 }
             }
         }
@@ -56,11 +60,20 @@ class MyPageFragment : BaseFragment<FragmentMyPageBinding>(R.layout.fragment_my_
     }
 
     private fun setupRecyclerView() {
-        binding.rvMusics.adapter = MusicAdapter(Orientation.VERTICAL)
+        binding.rvMusics.adapter = MusicAdapter(
+            musicItemOrientation = Orientation.VERTICAL,
+            listener = viewModel
+        )
     }
 
     override fun onStart() {
         super.onStart()
         viewModel.fetchMyMusics(count = 3)
     }
+}
+
+private fun NavController.navigateToPlayerScreen() {
+    val request =
+        NavDeepLinkRequest.Builder.fromUri("android-app://com.ohdodok.catchytape/player_fragment".toUri()).build()
+    navigate(request)
 }

--- a/android/feature/mypage/src/main/java/com/ohdodok/catchytape/feature/mypage/MyPageViewModel.kt
+++ b/android/feature/mypage/src/main/java/com/ohdodok/catchytape/feature/mypage/MyPageViewModel.kt
@@ -6,6 +6,8 @@ import com.ohdodok.catchytape.core.domain.model.CtErrorType
 import com.ohdodok.catchytape.core.domain.model.CtException
 import com.ohdodok.catchytape.core.domain.model.Music
 import com.ohdodok.catchytape.core.domain.repository.MusicRepository
+import com.ohdodok.catchytape.core.domain.usecase.player.CurrentPlaylistUseCase
+import com.ohdodok.catchytape.core.ui.MusicAdapter
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -28,7 +30,8 @@ data class MyPageUiState(
 @HiltViewModel
 class MyPageViewModel @Inject constructor(
     private val musicRepository: MusicRepository,
-) : ViewModel() {
+    private val currentPlaylistUseCase: CurrentPlaylistUseCase,
+) : ViewModel(), MusicAdapter.Listener {
 
     private val _uiState = MutableStateFlow(MyPageUiState())
     val uiState: StateFlow<MyPageUiState> = _uiState.asStateFlow()
@@ -55,8 +58,16 @@ class MyPageViewModel @Inject constructor(
             }
             .launchIn(viewModelScopeWithExceptionHandler)
     }
+
+    override fun onClick(music: Music) {
+        currentPlaylistUseCase.playMusic(music)
+        viewModelScope.launch {
+            _events.emit(MyPageEvent.NavigateToPlayerScreen)
+        }
+    }
 }
 
 sealed interface MyPageEvent {
     data class ShowMessage(val error: CtErrorType) : MyPageEvent
+    data object NavigateToPlayerScreen : MyPageEvent
 }

--- a/android/feature/player/src/main/java/com/ohdodok/catchytape/feature/player/PlayerFragment.kt
+++ b/android/feature/player/src/main/java/com/ohdodok/catchytape/feature/player/PlayerFragment.kt
@@ -9,7 +9,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.navigation.NavController
 import androidx.navigation.fragment.findNavController
-import com.ohdodok.catchytape.core.domain.utils.throttleFist
+import com.ohdodok.catchytape.core.domain.utils.throttleFirst
 import com.ohdodok.catchytape.core.ui.BaseFragment
 import com.ohdodok.catchytape.core.ui.RootViewInsetsCallback
 import com.ohdodok.catchytape.feature.player.databinding.FragmentPlayerBinding
@@ -71,12 +71,10 @@ class PlayerFragment : BaseFragment<FragmentPlayerBinding>(R.layout.fragment_pla
             player.onPreviousBtnClick()
         }
 
-        binding.btnAddToPlaylist.setOnClickListener {
-            clicksFlow(view = it).throttleFist(500)
-                .onEach {
-                    findNavController().showPlaylistBottomSheet()
-                }.launchIn(viewLifecycleOwner.lifecycleScope)
-        }
+        clicksFlow(view = binding.btnAddToPlaylist)
+            .throttleFirst(500)
+            .onEach { findNavController().showPlaylistBottomSheet() }
+            .launchIn(viewLifecycleOwner.lifecycleScope)
     }
 
     private fun NavController.showPlaylistBottomSheet() {

--- a/android/feature/player/src/main/java/com/ohdodok/catchytape/feature/player/PlayerFragment.kt
+++ b/android/feature/player/src/main/java/com/ohdodok/catchytape/feature/player/PlayerFragment.kt
@@ -5,13 +5,17 @@ import android.view.View
 import android.widget.SeekBar
 import androidx.core.view.ViewCompat
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.lifecycleScope
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.navigation.NavController
 import androidx.navigation.fragment.findNavController
+import com.ohdodok.catchytape.core.domain.utils.throttleFist
 import com.ohdodok.catchytape.core.ui.BaseFragment
 import com.ohdodok.catchytape.core.ui.RootViewInsetsCallback
 import com.ohdodok.catchytape.feature.player.databinding.FragmentPlayerBinding
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import javax.inject.Inject
 
 const val millisecondsPerSecond = 1000
@@ -68,14 +72,15 @@ class PlayerFragment : BaseFragment<FragmentPlayerBinding>(R.layout.fragment_pla
         }
 
         binding.btnAddToPlaylist.setOnClickListener {
-            findNavController().showPlaylistBottomSheet()
+            clicksFlow(view = it).throttleFist(500)
+                .onEach {
+                    findNavController().showPlaylistBottomSheet()
+                }.launchIn(viewLifecycleOwner.lifecycleScope)
         }
     }
 
     private fun NavController.showPlaylistBottomSheet() {
         val musicId = viewModel.uiState.value.currentMusic?.id ?: return
-
-
         val action = PlayerFragmentDirections.actionPlayerFragmentToPlaylistBottomSheet(musicId = musicId)
         navigate(action)
     }
@@ -84,3 +89,4 @@ class PlayerFragment : BaseFragment<FragmentPlayerBinding>(R.layout.fragment_pla
 fun NavController.navigateToPlayer() {
     navigate(R.id.player_nav_graph)
 }
+

--- a/android/feature/player/src/main/java/com/ohdodok/catchytape/feature/player/PlayerFragment.kt
+++ b/android/feature/player/src/main/java/com/ohdodok/catchytape/feature/player/PlayerFragment.kt
@@ -75,11 +75,12 @@ class PlayerFragment : BaseFragment<FragmentPlayerBinding>(R.layout.fragment_pla
     private fun NavController.showPlaylistBottomSheet() {
         val musicId = viewModel.uiState.value.currentMusic?.id ?: return
 
+
         val action = PlayerFragmentDirections.actionPlayerFragmentToPlaylistBottomSheet(musicId = musicId)
-        this.navigate(action)
+        navigate(action)
     }
 }
 
 fun NavController.navigateToPlayer() {
-    this.navigate(R.id.player_nav_graph)
+    navigate(R.id.player_nav_graph)
 }

--- a/android/feature/player/src/main/java/com/ohdodok/catchytape/feature/player/PlayerFragment.kt
+++ b/android/feature/player/src/main/java/com/ohdodok/catchytape/feature/player/PlayerFragment.kt
@@ -12,6 +12,7 @@ import androidx.navigation.fragment.findNavController
 import com.ohdodok.catchytape.core.domain.utils.throttleFirst
 import com.ohdodok.catchytape.core.ui.BaseFragment
 import com.ohdodok.catchytape.core.ui.RootViewInsetsCallback
+import com.ohdodok.catchytape.core.ui.clicksFlow
 import com.ohdodok.catchytape.feature.player.databinding.FragmentPlayerBinding
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.launchIn
@@ -71,7 +72,7 @@ class PlayerFragment : BaseFragment<FragmentPlayerBinding>(R.layout.fragment_pla
             player.onPreviousBtnClick()
         }
 
-        clicksFlow(view = binding.btnAddToPlaylist)
+        binding.btnAddToPlaylist.clicksFlow()
             .throttleFirst(500)
             .onEach { findNavController().showPlaylistBottomSheet() }
             .launchIn(viewLifecycleOwner.lifecycleScope)

--- a/android/feature/player/src/main/java/com/ohdodok/catchytape/feature/player/PlayerViewModel.kt
+++ b/android/feature/player/src/main/java/com/ohdodok/catchytape/feature/player/PlayerViewModel.kt
@@ -69,9 +69,7 @@ class PlayerViewModel @Inject constructor(
         viewModelScope.launch(exceptionHandler) {
             for (currentPlaylist in currentPlaylistUseCase.currentPlaylist) {
                 _currentPlaylist.value = currentPlaylist.musics
-                if (currentPlaylist.startMusic.id != _uiState.value.currentMusic?.id) {
-                    _events.emit(PlayerEvent.PlaylistChanged(currentPlaylist))
-                }
+                _events.emit(PlayerEvent.PlaylistChanged(currentPlaylist))
             }
         }
     }

--- a/android/feature/player/src/main/java/com/ohdodok/catchytape/feature/player/PlayerViewModel.kt
+++ b/android/feature/player/src/main/java/com/ohdodok/catchytape/feature/player/PlayerViewModel.kt
@@ -1,6 +1,7 @@
 package com.ohdodok.catchytape.feature.player
 
 import androidx.lifecycle.ViewModel
+
 import androidx.lifecycle.viewModelScope
 import com.ohdodok.catchytape.core.domain.model.CtErrorType
 import com.ohdodok.catchytape.core.domain.model.CtException
@@ -28,7 +29,6 @@ data class PlayerState(
     val duration: Int = 0,
     val isNextEnable: Boolean = false,
     val isPreviousEnable: Boolean = false
-
 ) {
     val isPlayEnable: Boolean
         get() = currentMusic != null
@@ -69,7 +69,9 @@ class PlayerViewModel @Inject constructor(
         viewModelScope.launch(exceptionHandler) {
             for (currentPlaylist in currentPlaylistUseCase.currentPlaylist) {
                 _currentPlaylist.value = currentPlaylist.musics
-                _events.emit(PlayerEvent.PlaylistChanged(currentPlaylist))
+                if (currentPlaylist.startMusic.id != _uiState.value.currentMusic?.id) {
+                    _events.emit(PlayerEvent.PlaylistChanged(currentPlaylist))
+                }
             }
         }
     }

--- a/android/feature/playlist/src/main/java/com/ohdodok/catchytape/feature/playlist/PlaylistDetailFragment.kt
+++ b/android/feature/playlist/src/main/java/com/ohdodok/catchytape/feature/playlist/PlaylistDetailFragment.kt
@@ -53,5 +53,5 @@ private fun NavController.navigateToPlayerScreen() {
     val targetUri = "android-app://com.ohdodok.catchytape/player_fragment".toUri()
     val request = NavDeepLinkRequest.Builder.fromUri(targetUri).build()
 
-    this.navigate(request)
+    navigate(request)
 }

--- a/android/feature/playlist/src/main/java/com/ohdodok/catchytape/feature/playlist/PlaylistsFragment.kt
+++ b/android/feature/playlist/src/main/java/com/ohdodok/catchytape/feature/playlist/PlaylistsFragment.kt
@@ -33,10 +33,11 @@ class PlaylistsFragment : BaseFragment<FragmentPlaylistsBinding>(R.layout.fragme
         viewModel.fetchPlaylists()
 
         observeEvents()
-        setupButton(NewPlaylistDialog())
+        setupButton()
     }
 
-    private fun setupButton(newPlaylistDialog: NewPlaylistDialog) {
+    private fun setupButton() {
+        val newPlaylistDialog = NewPlaylistDialog()
         binding.fabNewPlaylist.clicksFlow()
             .throttleFirst(500)
             .onEach { newPlaylistDialog.show(childFragmentManager, NewPlaylistDialog.TAG) }

--- a/android/feature/playlist/src/main/java/com/ohdodok/catchytape/feature/playlist/PlaylistsFragment.kt
+++ b/android/feature/playlist/src/main/java/com/ohdodok/catchytape/feature/playlist/PlaylistsFragment.kt
@@ -8,7 +8,7 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavController
 import androidx.navigation.fragment.findNavController
-import com.ohdodok.catchytape.core.domain.utils.throttleFist
+import com.ohdodok.catchytape.core.domain.utils.throttleFirst
 import com.ohdodok.catchytape.core.ui.BaseFragment
 import com.ohdodok.catchytape.core.ui.PlaylistAdapter
 import com.ohdodok.catchytape.core.ui.RootViewInsetsCallback
@@ -36,12 +36,10 @@ class PlaylistsFragment : BaseFragment<FragmentPlaylistsBinding>(R.layout.fragme
     }
 
     private fun setupButton(newPlaylistDialog: NewPlaylistDialog) {
-        binding.fabNewPlaylist.setOnClickListener {
-            clicksFlow(view = it).throttleFist(500)
-                .onEach {
-                    newPlaylistDialog.show(childFragmentManager, NewPlaylistDialog.TAG)
-                }.launchIn(viewLifecycleOwner.lifecycleScope)
-        }
+        clicksFlow(view = binding.fabNewPlaylist)
+            .throttleFirst(500)
+            .onEach { newPlaylistDialog.show(childFragmentManager, NewPlaylistDialog.TAG) }
+            .launchIn(viewLifecycleOwner.lifecycleScope)
     }
 
     private fun observeEvents() {

--- a/android/feature/playlist/src/main/java/com/ohdodok/catchytape/feature/playlist/PlaylistsFragment.kt
+++ b/android/feature/playlist/src/main/java/com/ohdodok/catchytape/feature/playlist/PlaylistsFragment.kt
@@ -5,14 +5,18 @@ import android.view.View
 import androidx.core.view.ViewCompat
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavController
 import androidx.navigation.fragment.findNavController
+import com.ohdodok.catchytape.core.domain.utils.throttleFist
 import com.ohdodok.catchytape.core.ui.BaseFragment
 import com.ohdodok.catchytape.core.ui.PlaylistAdapter
 import com.ohdodok.catchytape.core.ui.RootViewInsetsCallback
 import com.ohdodok.catchytape.core.ui.cterror.toMessageId
 import com.ohdodok.catchytape.feature.playlist.databinding.FragmentPlaylistsBinding
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 
 @AndroidEntryPoint
 class PlaylistsFragment : BaseFragment<FragmentPlaylistsBinding>(R.layout.fragment_playlists),
@@ -28,11 +32,16 @@ class PlaylistsFragment : BaseFragment<FragmentPlaylistsBinding>(R.layout.fragme
         viewModel.fetchPlaylists()
 
         observeEvents()
-        val newPlaylistDialog = NewPlaylistDialog()
-        binding.fabNewPlaylist.setOnClickListener {
-            newPlaylistDialog.show(childFragmentManager, NewPlaylistDialog.TAG)
-        }
+        setupButton(NewPlaylistDialog())
+    }
 
+    private fun setupButton(newPlaylistDialog: NewPlaylistDialog) {
+        binding.fabNewPlaylist.setOnClickListener {
+            clicksFlow(view = it).throttleFist(500)
+                .onEach {
+                    newPlaylistDialog.show(childFragmentManager, NewPlaylistDialog.TAG)
+                }.launchIn(viewLifecycleOwner.lifecycleScope)
+        }
     }
 
     private fun observeEvents() {

--- a/android/feature/playlist/src/main/java/com/ohdodok/catchytape/feature/playlist/PlaylistsFragment.kt
+++ b/android/feature/playlist/src/main/java/com/ohdodok/catchytape/feature/playlist/PlaylistsFragment.kt
@@ -12,6 +12,7 @@ import com.ohdodok.catchytape.core.domain.utils.throttleFirst
 import com.ohdodok.catchytape.core.ui.BaseFragment
 import com.ohdodok.catchytape.core.ui.PlaylistAdapter
 import com.ohdodok.catchytape.core.ui.RootViewInsetsCallback
+import com.ohdodok.catchytape.core.ui.clicksFlow
 import com.ohdodok.catchytape.core.ui.cterror.toMessageId
 import com.ohdodok.catchytape.feature.playlist.databinding.FragmentPlaylistsBinding
 import dagger.hilt.android.AndroidEntryPoint
@@ -36,7 +37,7 @@ class PlaylistsFragment : BaseFragment<FragmentPlaylistsBinding>(R.layout.fragme
     }
 
     private fun setupButton(newPlaylistDialog: NewPlaylistDialog) {
-        clicksFlow(view = binding.fabNewPlaylist)
+        binding.fabNewPlaylist.clicksFlow()
             .throttleFirst(500)
             .onEach { newPlaylistDialog.show(childFragmentManager, NewPlaylistDialog.TAG) }
             .launchIn(viewLifecycleOwner.lifecycleScope)

--- a/android/feature/search/src/main/java/com/ohdodok/catchytape/feature/search/SearchFragment.kt
+++ b/android/feature/search/src/main/java/com/ohdodok/catchytape/feature/search/SearchFragment.kt
@@ -19,19 +19,15 @@ import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class SearchFragment : BaseFragment<FragmentSearchBinding>(R.layout.fragment_search) {
-
     private val viewModel: SearchViewModel by viewModels()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
         ViewCompat.setOnApplyWindowInsetsListener(binding.root, RootViewInsetsCallback())
-
         binding.viewModel = viewModel
-
         observeEvents()
         setupRecyclerView()
-
     }
 
     private fun setupRecyclerView() {

--- a/android/feature/search/src/main/java/com/ohdodok/catchytape/feature/search/SearchFragment.kt
+++ b/android/feature/search/src/main/java/com/ohdodok/catchytape/feature/search/SearchFragment.kt
@@ -65,5 +65,5 @@ private fun NavController.navigateToPlayerScreen() {
         NavDeepLinkRequest.Builder.fromUri("android-app://com.ohdodok.catchytape/player_fragment".toUri())
             .build()
 
-    this.navigate(request)
+    navigate(request)
 }

--- a/android/feature/upload/src/main/res/layout/fragment_upload.xml
+++ b/android/feature/upload/src/main/res/layout/fragment_upload.xml
@@ -113,6 +113,8 @@
             <com.google.android.material.textfield.TextInputEditText
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:imeOptions="actionDone"
+                android:inputType="text"
                 android:onTextChanged="@{(text, start, before, count) -> viewModel.updateMusicTitle(text)}" />
 
         </com.google.android.material.textfield.TextInputLayout>


### PR DESCRIPTION
## Issue
- #338 
- #340

## Overview

- 플레이리스트 추가 bottom 짤리는 ui
- Player에서 ‘저장’ 빠르게 두번 누르면, 앱 터짐
   - throttleFirst 사용 
- 화면 회전 금지
- MyPage, MyMusics에서 노래 클릭시 해당 곡의 Player로 이동
- 새 재생목록 추가 버튼 클릭 throttleFist 처리 

## Screenshot
<img width="334" alt="스크린샷 2023-12-12 23 19 57" src="https://github.com/boostcampwm2023/and04-catchy-tape/assets/59787852/c4061afe-1675-4eac-9faf-3237eda3ad2d">

