### PR TITLE
사용자의 플레이리스트 삭제 API 추가

### DIFF
--- a/server/src/playlist/playlist.controller.ts
+++ b/server/src/playlist/playlist.controller.ts
@@ -90,6 +90,22 @@ export class PlaylistController {
     return await this.playlistService.getPlaylistMusics(userId, playlistId);
   }
 
+  @Delete()
+  @UseGuards(AuthGuard())
+  @HttpCode(HTTP_STATUS_CODE.SUCCESS)
+  async deletePlaylist(
+    @Req() req,
+    @Body('playlistId') playlistId: number,
+  ): Promise<{ playlistId: number }> {
+    this.logger.log(
+      `DELETE /playlists - nickname=${req.user.nickname}, playlistId=${playlistId}`,
+    );
+    const userId: string = req.user.user_id;
+    const deletedPlaylistId: number =
+      await this.playlistService.deleteSinglePlaylist(userId, playlistId);
+    return { playlistId: deletedPlaylistId };
+  }
+
   @Delete(':playlistId')
   @UseGuards(AuthGuard())
   @HttpCode(HTTP_STATUS_CODE.SUCCESS)


### PR DESCRIPTION
## Issue
- #366 

## Overview
* DB에서 해당 playlist 부분 삭제
* DB에서 music_playlist 테이블에 있는 레코드 중 해당 playlist에 담긴 음악 부분 모두 삭제
* 트랜잭션 추가 (중간에 Error 터졌을 때 롤백 되는 것을 확인)
* 정상적으로 동작할 때 DB에 playlist 테이블에서 해당 플레이리스트가 삭제되고, music_playlist 테이블에서 해당 플레이리스트의 음악 행들이 삭제됨을 확인

## Screenshot 
- 삭제 할 플레이리스트와, 그 안에 담긴 음악 정보
![스크린샷 2024-01-09 152218](https://github.com/boostcampwm2023/and04-catchy-tape/assets/83707411/b0cb19ce-638c-45cf-a6f1-7c698249dd92)
![스크린샷 2024-01-09 152227](https://github.com/boostcampwm2023/and04-catchy-tape/assets/83707411/c0d2dd9c-5a86-4742-b975-35bb41f26f99)
- 삭제가 정상적으로 이뤄졌을 때
![스크린샷 2024-01-09 153118](https://github.com/boostcampwm2023/and04-catchy-tape/assets/83707411/ea9e21f8-002a-4946-9be0-b919641c50ad)
- 중간에 에러가 발생했을 때 (롤백)
![스크린샷 2024-01-09 153739](https://github.com/boostcampwm2023/and04-catchy-tape/assets/83707411/d264ecc9-f7c5-4c20-97dd-d4454b081178)

## To Reviewers 
 로직이 이상하거나 추가해야 될 부분이 있으면 말해주세요!
