### PR TITLE
노래 삭제 API 구현

### DIFF
--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -24,3 +24,5 @@ export const contentTypeHandler: Record<string, string> = {
 export const getTimeStamp = (): number => {
   return new Date().getTime();
 };
+
+export const SLICE_COUNT: number = 'https://catchy-tape-bucket2.kr.object.ncloudstorage.com/'.length;

--- a/server/src/entity/music.entity.ts
+++ b/server/src/entity/music.entity.ts
@@ -136,4 +136,22 @@ export class Music extends BaseEntity {
       },
     });
   }
+
+  static async isExistMusicId(musicId: string): Promise<boolean> {
+    const count: number = await this.count({ where: { music_id: musicId } });
+    if (count === 0) {
+      return false;
+    }
+    return true;
+  }
+
+  static async isMusicOwner(musicId: string, userId: string): Promise<boolean> {
+    const count: number = await this.count({
+      where: { music_id: musicId, user: { user_id: userId } },
+    });
+    if (count === 0) {
+      return false;
+    }
+    return true;
+  }
 }

--- a/server/src/entity/music_playlist.entity.ts
+++ b/server/src/entity/music_playlist.entity.ts
@@ -15,7 +15,9 @@ export class Music_Playlist extends BaseEntity {
   @PrimaryGeneratedColumn()
   music_playlist_id: number;
 
-  @ManyToOne(() => Music, (music) => music.music_playlist)
+  @ManyToOne(() => Music, (music) => music.music_playlist, {
+    onDelete: 'CASCADE',
+  })
   @JoinColumn({ name: 'music_id' })
   music: Music;
 

--- a/server/src/entity/recent_played.entity.ts
+++ b/server/src/entity/recent_played.entity.ts
@@ -16,7 +16,9 @@ export class Recent_Played extends BaseEntity {
   @PrimaryGeneratedColumn()
   recent_played_id: number;
 
-  @ManyToOne(() => Music, (music) => music.recent_played)
+  @ManyToOne(() => Music, (music) => music.recent_played, {
+    onDelete: 'CASCADE',
+  })
   @JoinColumn({ name: 'music_id' })
   music: Music;
 

--- a/server/src/music/music.controller.ts
+++ b/server/src/music/music.controller.ts
@@ -10,6 +10,7 @@ import {
   ValidationPipe,
   Query,
   Logger,
+  Delete,
 } from '@nestjs/common';
 import { MusicService } from './music.service';
 import { HTTP_STATUS_CODE } from 'src/httpStatusCode.enum';
@@ -22,9 +23,7 @@ import { Music } from 'src/entity/music.entity';
 export class MusicController {
   private readonly logger = new Logger('Music');
   private objectStorage: AWS.S3;
-  constructor(
-    private readonly musicService: MusicService,
-  ) {}
+  constructor(private readonly musicService: MusicService) {}
 
   @Post()
   @UsePipes(ValidationPipe)
@@ -102,5 +101,16 @@ export class MusicController {
   ): Promise<Music[]> {
     this.logger.log(`GET /musics/search - keyword=${keyword}`);
     return this.musicService.getCertainKeywordNicknameUser(keyword);
+  }
+
+  @Delete()
+  @UseGuards(AuthGuard())
+  @HttpCode(HTTP_STATUS_CODE.SUCCESS)
+  async deleteMusic(
+    @Req() req,
+    @Body('music_id') music_id: string,
+  ): Promise<string> {
+    const userId = req.user.user_id;
+    return await this.musicService.deleteMusicById(music_id, userId);
   }
 }

--- a/server/src/music/music.service.ts
+++ b/server/src/music/music.service.ts
@@ -4,7 +4,7 @@ import { Repository, DataSource } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
 import { MusicCreateDto } from 'src/dto/musicCreate.dto';
 import { Music } from 'src/entity/music.entity';
-import { Genres } from 'src/constants';
+import { Genres, SLICE_COUNT } from 'src/constants';
 import { CatchyException } from 'src/config/catchyException';
 import { ERROR_CODE } from 'src/config/errorCode.enum';
 import { UploadService } from 'src/upload/upload.service';
@@ -203,11 +203,8 @@ export class MusicService {
       const music: Music = await Music.getMusicById(musicId);
       this.musicRepository.delete(music.music_id);
 
-      const sliceCount: number =
-        'https://catchy-tape-bucket2.kr.object.ncloudstorage.com/'.length;
-      const musicFilePath: string = music.music_file.slice(sliceCount, sliceCount + 41);
-      const coverFilePath: string = music.cover.slice(sliceCount, sliceCount + 46);
-      console.log(coverFilePath, musicFilePath);
+      const musicFilePath: string = music.music_file.slice(SLICE_COUNT, SLICE_COUNT + 41);
+      const coverFilePath: string = music.cover.slice(SLICE_COUNT, SLICE_COUNT + 46);
 
       if (musicFilePath) this.deleteFolder(musicFilePath);
       if (coverFilePath) this.deleteFolder(coverFilePath);

--- a/server/src/music/music.service.ts
+++ b/server/src/music/music.service.ts
@@ -10,6 +10,7 @@ import { ERROR_CODE } from 'src/config/errorCode.enum';
 import { UploadService } from 'src/upload/upload.service';
 import { NcloudConfigService } from 'src/config/ncloud.config';
 import { AWSError } from 'aws-sdk';
+import { DeleteObjectOutput } from 'aws-sdk/clients/s3';
 
 @Injectable()
 export class MusicService {
@@ -184,6 +185,91 @@ export class MusicService {
         'QUERY_ERROR',
         HTTP_STATUS_CODE.SERVER_ERROR,
         ERROR_CODE.QUERY_ERROR,
+      );
+    }
+  }
+
+  async deleteMusicById(musicId: string, userId: string): Promise<string> {
+    if (!(await Music.isMusicOwner(musicId, userId))) {
+      this.logger.error(`music.service - deleteMusicById : NOT_EXIST_MUSIC`);
+      throw new CatchyException(
+        'NOT_EXIST_MUSIC',
+        HTTP_STATUS_CODE.SERVER_ERROR,
+        ERROR_CODE.NOT_EXIST_MUSIC,
+      );
+    }
+
+    try {
+      const music: Music = await Music.getMusicById(musicId);
+      this.musicRepository.delete(music.music_id);
+
+      const sliceCount: number =
+        'https://catchy-tape-bucket2.kr.object.ncloudstorage.com/'.length;
+      const musicFilePath: string = music.music_file.slice(sliceCount, sliceCount + 41);
+      const coverFilePath: string = music.cover.slice(sliceCount, sliceCount + 46);
+      console.log(coverFilePath, musicFilePath);
+
+      if (musicFilePath) this.deleteFolder(musicFilePath);
+      if (coverFilePath) this.deleteFolder(coverFilePath);
+
+      return music.music_id;
+    } catch {
+      this.logger.error(`music.service - deleteMusicById : SERVICE_ERROR`);
+      throw new CatchyException(
+        'SERVICE_ERROR',
+        HTTP_STATUS_CODE.SERVER_ERROR,
+        ERROR_CODE.SERVICE_ERROR,
+      );
+    }
+  }
+
+  async deleteFolder(folderPath) {
+    let params = {
+      Bucket: 'catchy-tape-bucket2',
+      Delete: {
+        Objects: [],
+      },
+    };
+
+    // 폴더 내의 파일들을 삭제할 객체 목록에 추가
+    const filesInFolder = await this.listFilesInFolder(folderPath);
+    filesInFolder.forEach((file) => {
+      params.Delete.Objects.push({ Key: file.Key });
+    });
+
+    try {
+      // 폴더 내의 파일들을 삭제
+      await this.objectStorage.deleteObjects(params).promise();
+
+      // 폴더를 삭제
+      await this.objectStorage
+        .deleteObject({ Bucket: 'catchy-tape-bucket2', Key: folderPath })
+        .promise();
+    } catch (error) {
+      this.logger.error(`music.service - deleteFolder : SERVICE_ERROR`);
+      throw new CatchyException(
+        'SERVICE_ERROR',
+        HTTP_STATUS_CODE.SERVER_ERROR,
+        ERROR_CODE.SERVICE_ERROR,
+      );
+    }
+  }
+
+  async listFilesInFolder(folderPath) {
+    let params = {
+      Bucket: 'catchy-tape-bucket2',
+      Prefix: folderPath,
+    };
+
+    try {
+      const data = await this.objectStorage.listObjectsV2(params).promise();
+      return data.Contents;
+    } catch (error) {
+      this.logger.error(`music.service - listFilesInFolder : SERVICE_ERROR`);
+      throw new CatchyException(
+        'SERVICE_ERROR',
+        HTTP_STATUS_CODE.SERVER_ERROR,
+        ERROR_CODE.SERVICE_ERROR,
       );
     }
   }


### PR DESCRIPTION
## Issue
- #352 

## Overview
- 관계에 casecade 설정을 넣어서 music 이 삭제되면 그 음악을 가지고 있는 music_playlist 와 recent_played 객체도 삭제되도록 설정했습니다.
- db 에서 해당 음악파일과 커버사진을 저장하고 있는 폴더를 삭제하도록 구현했습니다.
- 현재 object storage 에서 삭제하다가 오류가 생기면 DB 삭제 롤백은 안되어있어서 트랜잭션 추가가 필요합니다. (추가 예정)

- 테스트도 해서 작동 확인을 했는데 다시 테스트하기가 번거로워서 사진은 추가하지 않겠습니다.

## To Reviewers
실수한 부분이 있어보인다면 알려주세요!