### PR TITLE
Active Record 패턴으로 리팩토링

### DIFF
--- a/server/src/auth/auth.service.ts
+++ b/server/src/auth/auth.service.ts
@@ -19,10 +19,7 @@ export class AuthService {
   ) {}
 
   async login(email: string): Promise<{ accessToken: string }> {
-    const user: User = await this.userRepository.findOneBy({
-      user_email: email,
-      is_deleted: false,
-    });
+    const user: User = await User.findUserByEmail(email);
 
     if (user) {
       const payload = { user_id: user['user_id'] };
@@ -105,10 +102,7 @@ export class AuthService {
   }
 
   async isExistEmail(email: string): Promise<boolean> {
-    const user: User = await this.userRepository.findOneBy({
-      user_email: email,
-      is_deleted: false,
-    });
+    const user: User = await User.findUserByEmail(email);
 
     if (!user) {
       return false;

--- a/server/src/auth/jwt.strategy.ts
+++ b/server/src/auth/jwt.strategy.ts
@@ -25,9 +25,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   async validate(payload): Promise<User> {
     const { user_id } = payload;
 
-    const user: User = await this.userRepository.findOne({
-      where: { user_id, is_deleted: false },
-    });
+    const user: User = await User.findUserById(user_id);
 
     if (!user || !user_id) {
       this.logger.error(`request user_id=${user_id} : NOT_EXIST_USER`);

--- a/server/src/entity/music.entity.ts
+++ b/server/src/entity/music.entity.ts
@@ -77,6 +77,10 @@ export class Music extends BaseEntity {
     });
   }
 
+  static async countMusicById(musicId: string): Promise<number> {
+    return this.countBy({ music_id: musicId });
+  }
+
   static async getRecentMusic(): Promise<Music[]> {
     return this.find({
       relations: {

--- a/server/src/entity/music_playlist.entity.ts
+++ b/server/src/entity/music_playlist.entity.ts
@@ -30,6 +30,16 @@ export class Music_Playlist extends BaseEntity {
   @Index()
   created_at: Date;
 
+  static async countMusicNumberInPlaylist(
+    musicId: string,
+    playlistId: number,
+  ): Promise<number> {
+    return this.countBy({
+      music: { music_id: musicId },
+      playlist: { playlist_id: playlistId },
+    });
+  }
+
   static async getMusicListByPlaylistId(playlistId: number): Promise<Music[]> {
     return this.find({
       relations: {

--- a/server/src/entity/playlist.entity.ts
+++ b/server/src/entity/playlist.entity.ts
@@ -34,8 +34,18 @@ export class Playlist extends BaseEntity {
   @OneToMany(() => Music_Playlist, (music_playlist) => music_playlist.playlist)
   music_playlist: Music_Playlist[];
 
+  static async isExistPlaylistOnUser(
+    userId: string,
+    playlistId: number,
+  ): Promise<number> {
+    return this.countBy({
+      playlist_id: playlistId,
+      user: { user_id: userId },
+    });
+  }
+
   static async getPlaylistsByUserId(userId: string): Promise<Playlist[]> {
-    return this.find({
+    return await this.find({
       select: { playlist_id: true, playlist_title: true },
       where: {
         user: { user_id: userId },

--- a/server/src/entity/recent_played.entity.ts
+++ b/server/src/entity/recent_played.entity.ts
@@ -30,6 +30,41 @@ export class Recent_Played extends BaseEntity {
   @Index()
   played_at: Date;
 
+  static async countMusicNumberById(
+    music_id: string,
+    user_id: string,
+  ): Promise<number> {
+    return this.count({
+      where: { music: { music_id }, user: { user_id } },
+    });
+  }
+
+  static async getRecentPlayedId(
+    music_id: string,
+    user_id: string,
+  ): Promise<number> {
+    return (
+      await this.findOne({
+        where: { music: { music_id }, user: { user_id } },
+      })
+    ).recent_played_id;
+  }
+
+  static async getNumberOfRecentPlayedMusic(user_id: string): Promise<number> {
+    return this.count({
+      where: { user: { user_id } },
+    });
+  }
+
+  static async getRecentPlayedMusic(user_id: string): Promise<Recent_Played> {
+    return this.findOne({
+      relations: { music: true, user: true },
+      select: { music: { cover: true } },
+      where: { user: { user_id } },
+      order: { played_at: 'DESC' },
+    });
+  }
+
   static async getRecentPlayedMusicByUserId(
     user_id: string,
     count: number,
@@ -60,16 +95,5 @@ export class Recent_Played extends BaseEntity {
     }).then((recent_played: Recent_Played[]) =>
       recent_played.map((recent) => recent.music),
     );
-  }
-
-  static async getRecentPlayedId(
-    music_id: string,
-    user_id: string,
-  ): Promise<number> {
-    return (
-      await this.findOne({
-        where: { music: { music_id }, user: { user_id } },
-      })
-    ).recent_played_id;
   }
 }

--- a/server/src/entity/user.entity.ts
+++ b/server/src/entity/user.entity.ts
@@ -40,6 +40,29 @@ export class User extends BaseEntity {
   @OneToMany(() => Recent_Played, (recent_played) => recent_played.user)
   recent_played: Recent_Played[];
 
+  static async countNumberOfUserById(user_id: string): Promise<number> {
+    return this.count({ where: { user_id } });
+  }
+
+  static async findUserByNickName(nickname: string): Promise<User> {
+    return this.findOneBy({
+      nickname,
+    });
+  }
+
+  static async findUserById(user_id: string): Promise<User> {
+    return this.findOne({
+      where: { user_id, is_deleted: false },
+    });
+  }
+
+  static async findUserByEmail(user_email: string): Promise<User> {
+    return this.findOneBy({
+      user_email,
+      is_deleted: false,
+    });
+  }
+
   static async getCertainUserByNickname(keyword: string): Promise<User[]> {
     return this.find({
       relations: {
@@ -57,14 +80,5 @@ export class User extends BaseEntity {
         nickname: ILike(`%${keyword}%`),
       },
     });
-  }
-
-  static async isExistUserId(user_id: string): Promise<boolean> {
-    const count: number = await this.count({ where: { user_id } });
-    if (count === 0) {
-      return false;
-    } else {
-      return true;
-    }
   }
 }

--- a/server/src/playlist/playlist.service.ts
+++ b/server/src/playlist/playlist.service.ts
@@ -269,18 +269,21 @@ export class PlaylistService {
     await queryRunner.startTransaction();
 
     try {
+      await queryRunner.manager.delete(Music_Playlist, {
+        playlist: {
+          playlist_id: playlistId,
+        },
+      });
+
       await queryRunner.manager.delete(Playlist, {
         playlist_id: playlistId,
         user: { user_id: userId },
       });
 
-      await queryRunner.manager.delete(Music_Playlist, {
-        playlist_id: playlistId,
-      });
-
       await queryRunner.commitTransaction();
       return playlistId;
     } catch (error) {
+      console.log(error);
       await queryRunner.rollbackTransaction();
 
       if (error instanceof CatchyException) {

--- a/server/src/playlist/playlist.service.ts
+++ b/server/src/playlist/playlist.service.ts
@@ -111,13 +111,12 @@ export class PlaylistService {
           created_at: new Date(),
         });
 
-      const targetPlaylist: Playlist = await this.playlistRepository.findOne({
-        where: { playlist_id: playlistId },
-      });
-      targetPlaylist.updated_at = new Date();
-
       await queryRunner.manager.save(new_music_playlist);
-      await queryRunner.manager.save(targetPlaylist);
+      await queryRunner.manager.update(
+        Playlist,
+        { playlist_id: playlistId },
+        { updated_at: new Date() },
+      );
 
       await queryRunner.commitTransaction();
 
@@ -140,11 +139,12 @@ export class PlaylistService {
 
   async isAlreadyAdded(playlistId: number, musicId: string): Promise<boolean> {
     try {
-      const count: number = await this.music_playlistRepository.countBy({
-        music: { music_id: musicId },
-        playlist: { playlist_id: playlistId },
-      });
-      return count !== 0;
+      const musicNumber = await Music_Playlist.countMusicNumberInPlaylist(
+        musicId,
+        playlistId,
+      );
+
+      return musicNumber !== 0;
     } catch {
       this.logger.error(`playlist.service - isAlreadyAdded : SERVICE_ERROR`);
       throw new CatchyException(
@@ -160,11 +160,12 @@ export class PlaylistService {
     userId: string,
   ): Promise<boolean> {
     try {
-      const playlistCount: number = await this.playlistRepository.countBy({
-        playlist_id: playlistId,
-        user: { user_id: userId },
-      });
-      return playlistCount !== 0;
+      const playlistNumber = await Playlist.isExistPlaylistOnUser(
+        userId,
+        playlistId,
+      );
+
+      return playlistNumber !== 0;
     } catch {
       this.logger.error(
         `playlist.service - isExistPlaylistOnUser : SERVICE_ERROR`,
@@ -179,9 +180,7 @@ export class PlaylistService {
 
   async isExistMusic(musicId: string): Promise<boolean> {
     try {
-      const musicCount: number = await this.MusicRepository.countBy({
-        music_id: musicId,
-      });
+      const musicCount: number = await Music.countMusicById(musicId);
 
       return musicCount !== 0;
     } catch {
@@ -197,18 +196,22 @@ export class PlaylistService {
   async getUserPlaylists(userId: string): Promise<Playlist[]> {
     try {
       const playlists: Playlist[] = await Playlist.getPlaylistsByUserId(userId);
+
       const countPromises = playlists.map(async (playlist) => {
         playlist['music_count'] =
           await Music_Playlist.getMusicCountByPlaylistId(playlist.playlist_id);
       });
+
       const thumbnailPromises = playlists.map(async (playlist) => {
         const target = await Music_Playlist.getThumbnailByPlaylistId(
           playlist.playlist_id,
         );
         playlist['thumbnail'] = !target ? null : target.music.cover;
       });
+
       await Promise.all(countPromises);
       await Promise.all(thumbnailPromises);
+
       return playlists;
     } catch {
       this.logger.error(`playlist.service - getUserPlaylists : SERVICE_ERROR`);
@@ -266,26 +269,14 @@ export class PlaylistService {
     await queryRunner.startTransaction();
 
     try {
-      const target: Playlist = await this.playlistRepository.findOne({
-        where: {
-          playlist_id: playlistId,
-          user: {
-            user_id: userId,
-          },
-        },
+      await queryRunner.manager.delete(Playlist, {
+        playlist_id: playlistId,
+        user: { user_id: userId },
       });
 
-      const targetMusics: Music_Playlist[] =
-        await this.music_playlistRepository.find({
-          where: {
-            playlist: {
-              playlist_id: playlistId,
-            },
-          },
-        });
-
-      await queryRunner.manager.remove(targetMusics);
-      await queryRunner.manager.remove(target);
+      await queryRunner.manager.delete(Music_Playlist, {
+        playlist_id: playlistId,
+      });
 
       await queryRunner.commitTransaction();
       return playlistId;
@@ -349,7 +340,7 @@ export class PlaylistService {
           },
         });
 
-      const deletedMusicId: number = target.music_playlist_id;
+      const deletedMusicPlaylistId: number = target.music_playlist_id;
 
       if (target == undefined) {
         this.logger.error(
@@ -366,7 +357,7 @@ export class PlaylistService {
 
       await queryRunner.commitTransaction();
 
-      return deletedMusicId;
+      return deletedMusicPlaylistId;
     } catch (error) {
       await queryRunner.rollbackTransaction();
 

--- a/server/src/upload/upload.controller.ts
+++ b/server/src/upload/upload.controller.ts
@@ -18,7 +18,6 @@ import {
 import { UploadService } from './upload.service';
 import { HTTP_STATUS_CODE } from 'src/httpStatusCode.enum';
 import { AuthGuard } from '@nestjs/passport';
-import { v4 } from 'uuid';
 import { CatchyException } from 'src/config/catchyException';
 import { ERROR_CODE } from 'src/config/errorCode.enum';
 import { FileInterceptor } from '@nestjs/platform-express';
@@ -27,25 +26,14 @@ import { fileSize } from 'src/constants';
 @Controller('upload')
 export class UploadController {
   private readonly logger = new Logger('Upload');
-  constructor(
-    private uploadService: UploadService,
-  ) {}
+  constructor(private uploadService: UploadService) {}
 
   @Get('uuid')
   @UseGuards(AuthGuard())
   @HttpCode(HTTP_STATUS_CODE.SUCCESS)
   getMusicUUID(): { uuid: string } {
-    try {
-      this.logger.log(`GET /upload/uuid`);
-      return { uuid: v4() };
-    } catch (err) {
-      this.logger.error(`upload.controller - getMusicUUID : SERVER_ERROR`);
-      throw new CatchyException(
-        'SERVER ERROR',
-        HTTP_STATUS_CODE.SERVER_ERROR,
-        ERROR_CODE.SERVER_ERROR,
-      );
-    }
+    this.logger.log(`GET /upload/uuid`);
+    return { uuid: this.uploadService.getUUID() };
   }
 
   @Post('/music')
@@ -54,6 +42,7 @@ export class UploadController {
   @UseInterceptors(FileInterceptor('file'))
   @HttpCode(HTTP_STATUS_CODE.SUCCESS)
   async uploadMusic(
+    @Req() req,
     @UploadedFile(
       new ParseFilePipe({
         validators: [
@@ -65,16 +54,18 @@ export class UploadController {
     file: Express.Multer.File,
     @Body('uuid') uuid: string,
   ): Promise<{ url: string }> {
-    this.logger.log(`POST /upload/music - uuid=${uuid}`);
+    this.logger.log(
+      `POST /upload/music - nickname=${req.user.nickname}, uuid=${uuid}`,
+    );
     const { url } = await this.uploadService.uploadMusic(file, uuid);
     return { url };
   }
 
   @Post('/image')
   @UseGuards(AuthGuard())
-  @HttpCode(HTTP_STATUS_CODE.SUCCESS)
   @UsePipes(ValidationPipe)
   @UseInterceptors(FileInterceptor('file'))
+  @HttpCode(HTTP_STATUS_CODE.SUCCESS)
   async uploadImage(
     @Req() req,
     @UploadedFile(
@@ -92,25 +83,11 @@ export class UploadController {
     this.logger.log(
       `POST /upload/image - nickname=${req.user.nickname}, type=${type}, uuid=${uuid}`,
     );
-    try {
-      const userId = req.user.user_id;
-      const id = type === 'user' ? userId : uuid;
 
-      if (!id) {
-        throw new Error();
-      }
+    const userId = req.user.user_id;
+    const id = type === 'user' ? userId : uuid;
 
-      const { url } = await this.uploadService.uploadImage(file, id, type);
-      return { url };
-    } catch (err) {
-      if (err instanceof CatchyException) throw err;
-
-      this.logger.error(`upload.controller - uploadImage : NOT_EXIST_MUSIC_ID`);
-      throw new CatchyException(
-        'NOT_EXIST_MUSIC_ID',
-        HTTP_STATUS_CODE.BAD_REQUEST,
-        ERROR_CODE.NOT_EXIST_MUSIC_ID,
-      );
-    }
+    const { url } = await this.uploadService.uploadImage(file, id, type);
+    return { url };
   }
 }

--- a/server/src/upload/upload.service.ts
+++ b/server/src/upload/upload.service.ts
@@ -11,6 +11,7 @@ import { Readable } from 'stream';
 import { GreenEyeService } from '../config/greenEye.service';
 import { DeleteObjectOutput } from 'aws-sdk/clients/s3';
 import { CloudFunctionsResponseDto } from 'src/dto/cloudFunctions.response.dto';
+import { v4 } from 'uuid';
 
 @Injectable()
 export class UploadService {
@@ -49,6 +50,19 @@ export class UploadService {
         Key: path,
       })
       .promise();
+  }
+
+  getUUID(): string {
+    try {
+      return v4();
+    } catch {
+      this.logger.error(`upload.controller - getMusicUUID : SERVER_ERROR`);
+      throw new CatchyException(
+        'SERVER ERROR',
+        HTTP_STATUS_CODE.SERVER_ERROR,
+        ERROR_CODE.SERVER_ERROR,
+      );
+    }
   }
 
   async checkImageNormal(
@@ -161,6 +175,17 @@ export class UploadService {
     type: string,
   ): Promise<{ url: string }> {
     try {
+      if (!id) {
+        this.logger.error(
+          `upload.controller - uploadImage : NOT_EXIST_MUSIC_ID`,
+        );
+        throw new CatchyException(
+          'NOT_EXIST_MUSIC_ID',
+          HTTP_STATUS_CODE.BAD_REQUEST,
+          ERROR_CODE.NOT_EXIST_MUSIC_ID,
+        );
+      }
+
       if (!this.isValidUUIDPattern(id)) {
         this.logger.error(
           `upload.service - uploadImage : INVALID_INPUT_UUID_VALUE`,


### PR DESCRIPTION
## Issue
- #372 

## Overview
* 기존 조회 로직을 엔티티 단으로 옮겼을 뿐이라 Postman으로 이것저것 테스트 해봐서 스크린샷을 첨부하진 않았습니다!
(정말 간단히 리팩토링만 진행했습니다)


## To Reviewers 
* 다만 플레이리스트 자체를 삭제하는 로직에서 Music_Playlist 테이블의 플레이리스트 안의 음악 삭제 -> 플레이리스트 삭제에서 `onDelete: 'CASCADE'`를 적용해보려 했는데 잘 안되네요 ㅠㅠ 조언 부탁드립니다!
