### PR TITLE
Playlist Repository 생성

### DIFF
--- a/server/src/auth/auth.service.spec.ts
+++ b/server/src/auth/auth.service.spec.ts
@@ -9,6 +9,7 @@ import { Playlist } from 'src/entity/playlist.entity';
 import { Music } from 'src/entity/music.entity';
 import { Music_Playlist } from 'src/entity/music_playlist.entity';
 import { PassportModule } from '@nestjs/passport';
+import { PlaylistRepository } from 'src/playlist/playlist.repository';
 
 describe('AuthService', () => {
   let service: AuthService;
@@ -27,7 +28,7 @@ describe('AuthService', () => {
           useClass: Repository,
         },
         {
-          provide: getRepositoryToken(Playlist),
+          provide: PlaylistRepository,
           useClass: Repository,
         },
         {

--- a/server/src/entity/playlist.entity.ts
+++ b/server/src/entity/playlist.entity.ts
@@ -3,7 +3,6 @@ import {
   Column,
   CreateDateColumn,
   Entity,
-  EntityManager,
   Index,
   JoinColumn,
   ManyToOne,
@@ -12,16 +11,9 @@ import {
 } from 'typeorm';
 import { User } from './user.entity';
 import { Music_Playlist } from './music_playlist.entity';
-import { PlaylistCreateDto } from 'src/dto/playlistCreate.dto';
-import { CatchyException } from 'src/config/catchyException';
-import { Logger } from '@nestjs/common';
-import { HTTP_STATUS_CODE } from 'src/httpStatusCode.enum';
-import { ERROR_CODE } from 'src/config/errorCode.enum';
 
 @Entity({ name: 'playlist' })
 export class Playlist extends BaseEntity {
-  private static readonly logger: Logger = new Logger('PlaylistEntity');
-
   @PrimaryGeneratedColumn()
   playlist_id: number;
 
@@ -41,63 +33,4 @@ export class Playlist extends BaseEntity {
 
   @OneToMany(() => Music_Playlist, (music_playlist) => music_playlist.playlist)
   music_playlist: Music_Playlist[];
-
-  static async isExistPlaylistOnUser(
-    userId: string,
-    playlistId: number,
-  ): Promise<number> {
-    return this.countBy({
-      playlist_id: playlistId,
-      user: { user_id: userId },
-    });
-  }
-
-  static async getPlaylistsByUserId(userId: string): Promise<Playlist[]> {
-    return await this.find({
-      select: { playlist_id: true, playlist_title: true },
-      where: {
-        user: { user_id: userId },
-      },
-      order: {
-        updated_at: 'DESC',
-      },
-    });
-  }
-
-  static async createPlaylist(
-    userId: string,
-    playlistCreateDto: PlaylistCreateDto,
-  ): Promise<number> {
-    const entityManager: EntityManager = this.getRepository().manager;
-    const queryRunner = entityManager.connection.createQueryRunner();
-    await queryRunner.startTransaction();
-
-    try {
-      const title: string = playlistCreateDto.title;
-      const newPlaylist: Playlist = this.create({
-        playlist_title: title,
-        created_at: new Date(),
-        updated_at: new Date(),
-        user: { user_id: userId },
-      });
-
-      const result: Playlist = await queryRunner.manager.save(newPlaylist);
-      await queryRunner.commitTransaction();
-
-      const playlistId: number = result.playlist_id;
-
-      return playlistId;
-    } catch {
-      await queryRunner.rollbackTransaction();
-
-      this.logger.error(`playlist.entity - createPlaylist : ENTITY_ERROR`);
-      throw new CatchyException(
-        'ENTITY_ERROR',
-        HTTP_STATUS_CODE.SERVER_ERROR,
-        ERROR_CODE.ENTITY_ERROR,
-      );
-    } finally {
-      await queryRunner.release();
-    }
-  }
 }

--- a/server/src/playlist/playlist.module.ts
+++ b/server/src/playlist/playlist.module.ts
@@ -6,6 +6,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthModule } from 'src/auth/auth.module';
 import { Music_Playlist } from 'src/entity/music_playlist.entity';
 import { Music } from 'src/entity/music.entity';
+import { PlaylistRepository } from './playlist.repository';
 import { Logger } from 'winston';
 
 @Module({
@@ -14,7 +15,7 @@ import { Logger } from 'winston';
     AuthModule,
   ],
   controllers: [PlaylistController],
-  providers: [PlaylistService, Logger],
+  providers: [PlaylistService, PlaylistRepository, Logger],
   exports: [PlaylistService],
 })
 export class PlaylistModule {}

--- a/server/src/playlist/playlist.repository.ts
+++ b/server/src/playlist/playlist.repository.ts
@@ -1,0 +1,117 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { CatchyException } from 'src/config/catchyException';
+import { ERROR_CODE } from 'src/config/errorCode.enum';
+import { PlaylistCreateDto } from 'src/dto/playlistCreate.dto';
+import { Music_Playlist } from 'src/entity/music_playlist.entity';
+import { Playlist } from 'src/entity/playlist.entity';
+import { HTTP_STATUS_CODE } from 'src/httpStatusCode.enum';
+import { DataSource, QueryRunner, Repository } from 'typeorm';
+
+@Injectable()
+export class PlaylistRepository {
+  private playlistRepository: Repository<Playlist>;
+  private readonly logger: Logger = new Logger('PlaylistEntity');
+
+  constructor(private readonly dataSource: DataSource) {
+    this.playlistRepository = this.dataSource.getRepository(Playlist);
+  }
+
+  async isExistPlaylistOnUser(
+    userId: string,
+    playlistId: number,
+  ): Promise<number> {
+    return this.playlistRepository.countBy({
+      playlist_id: playlistId,
+      user: { user_id: userId },
+    });
+  }
+
+  async getPlaylistsByUserId(userId: string): Promise<Playlist[]> {
+    return await this.playlistRepository.find({
+      select: { playlist_id: true, playlist_title: true },
+      where: {
+        user: { user_id: userId },
+      },
+      order: {
+        updated_at: 'DESC',
+      },
+    });
+  }
+
+  async createPlaylist(
+    userId: string,
+    playlistCreateDto: PlaylistCreateDto,
+  ): Promise<number> {
+    const queryRunner: QueryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.startTransaction();
+
+    try {
+      const title: string = playlistCreateDto.title;
+      const newPlaylist: Playlist = this.playlistRepository.create({
+        playlist_title: title,
+        created_at: new Date(),
+        updated_at: new Date(),
+        user: { user_id: userId },
+      });
+
+      const result: Playlist = await queryRunner.manager.save(newPlaylist);
+      await queryRunner.commitTransaction();
+
+      const playlistId: number = result.playlist_id;
+
+      return playlistId;
+    } catch {
+      await queryRunner.rollbackTransaction();
+
+      this.logger.error(`playlist.repository - createPlaylist : ENTITY_ERROR`);
+      throw new CatchyException(
+        'ENTITY_ERROR',
+        HTTP_STATUS_CODE.SERVER_ERROR,
+        ERROR_CODE.ENTITY_ERROR,
+      );
+    } finally {
+      await queryRunner.release();
+    }
+  }
+
+  async deleteSinglePlaylist(
+    userId: string,
+    playlistId: number,
+  ): Promise<number> {
+    const queryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.startTransaction();
+
+    try {
+      await queryRunner.manager.delete(Music_Playlist, {
+        playlist: {
+          playlist_id: playlistId,
+        },
+      });
+
+      await queryRunner.manager.delete(Playlist, {
+        playlist_id: playlistId,
+        user: { user_id: userId },
+      });
+
+      await queryRunner.commitTransaction();
+      return playlistId;
+    } catch (error) {
+      await queryRunner.rollbackTransaction();
+
+      if (error instanceof CatchyException) {
+        throw error;
+      }
+
+      this.logger.error(
+        `playlist.repository - deleteSinglePlaylist : SERVICE_ERROR`,
+      );
+      throw new CatchyException(
+        'SERVICE_ERROR',
+        HTTP_STATUS_CODE.BAD_REQUEST,
+        ERROR_CODE.SERVICE_ERROR,
+      );
+    } finally {
+      await queryRunner.release();
+    }
+  }
+}


### PR DESCRIPTION
## Issue
- #384 

## Overview
- Data Mapper 패턴으로 전환을 위해 PlaylistRepository 를 생성하고 모든 쿼리문을 옮겼습니다.
  - Playlist entity 안에는 모든 쿼리문이 삭제됐습니다.
- 다만, playlist service 안에 있는 코드 중 일부는 다른 모듈과 연결되어 있어서 일부 남아있습니다.

## Screenshot 
- 변경한 함수들 모두 로컬 테스트 완료했습니다!
